### PR TITLE
Add code to flesh out backbone

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -426,7 +426,7 @@ minsize=2000
 %.physlr.stamp: \
 		%.physlr.overlap.n50.mol.backbone.path.$(ref).molecule.bed.$(ref).cov.tsv \
 		%.physlr.overlap.n50.mol.backbone.path.$(ref).molecule.bed.pdf \
-		%.physlr.overlap.n50.mol.backbone.label.gv.pdf
+		%.physlr.overlap.n50.mol.backbone.label.gv.pdf \
 		%.physlr.overlap.n50.mol.backbone.fleshed.all.path.$(ref).molecule.bed.pdf
 	touch $@
 

--- a/physlr/physlr.py
+++ b/physlr/physlr.py
@@ -162,7 +162,7 @@ class Physlr:
         return nx.algorithms.operators.binary.compose(g, graph)
 
     @staticmethod
-    def read_path(filename, min_component_size):
+    def read_path_filter(filename, min_component_size):
         "Read a path file, return a list of paths"
         paths = []
         with open(filename, 'r') as pathfile:
@@ -377,7 +377,7 @@ class Physlr:
     def physlr_flesh(self):
         "Flesh out the barcodes in the backbone paths"
         g = self.read_graph([self.args.FILES[0]])
-        backbones = self.read_path(self.args.FILES[1], self.args.min_component_size)
+        backbones = self.read_path_filter(self.args.FILES[1], self.args.min_component_size)
         for backbone in backbones:
             backbone_insertions = {}
             neighbours = set(v for u in backbone for v in g.neighbors(u))


### PR DESCRIPTION
Code added to physlr.py to flesh out molecule backbone with neighbouring molecules.
Code tested with chr4 of fly.