### PR TITLE
Calculate tfidf

### DIFF
--- a/physlr/physlr.py
+++ b/physlr/physlr.py
@@ -1049,7 +1049,6 @@ class Physlr:
         singletons = {mx for mx, n in progress(mx_counts.items()) if n < 2}
         for mxs in progress(bxtomxs.values()):
             mxs -= singletons
-
         print(
             int(timeit.default_timer() - t0),
             "Removed", len(singletons), "minimizers that occur only once of", len(mx_counts),
@@ -1057,7 +1056,6 @@ class Physlr:
         for mx in singletons:
             del mx_counts[mx]
         return mx_counts
-
 
     def physlr_calculate_minimizer_tfidf(self):
         """

--- a/physlr/physlr.py
+++ b/physlr/physlr.py
@@ -1066,10 +1066,10 @@ class Physlr:
         Write a minimizer to TFIDF dictionary to a pickle file.
         """
         bxtomxs = self.read_minimizers(self.args.FILES)
-        mxtobxs = self.construct_minimizers_to_barcodes(bxtomxs)
+        mx_counts = Counter(mx for mxs in progress(bxtomxs.values()) for mx in mxs)
 
         total_bx = len(bxtomxs.keys())
-        mxtotfidf = dict((mx, math.log(total_bx/len(bxs))) for mx, bxs in mxtobxs.items())
+        mxtotfidf = dict((mx, math.log(total_bx/occurence)) for mx, occurence in mx_counts.items())
 
         fileout = open(self.args.output, "wb")
         pickle.dump(mxtotfidf, fileout)

--- a/physlr/physlr.py
+++ b/physlr/physlr.py
@@ -1073,8 +1073,11 @@ class Physlr:
         pickle.dump(mxtotfidf, fileout)
         fileout.close()
 
-        print("Total", total_bx, "barcodes read.", sep=" ", end="\n", file=sys.stderr)
-        print("Total", len(mxtotfidf.keys()), "minimizers read.", sep=" ", end="\n", file=sys.stderr)
+        print(
+            "Total", total_bx, "barcodes read.", sep=" ", end="\n", file=sys.stderr)
+        print(
+            "Total", len(mxtotfidf.keys()), "minimizers read.",
+            sep=" ", end="\n", file=sys.stderr)
 
         return mxtotfidf
 

--- a/physlr/physlr.py
+++ b/physlr/physlr.py
@@ -1073,8 +1073,10 @@ class Physlr:
         pickle.dump(mxtotfidf, fileout)
         fileout.close()
 
-        print("Total", total_bx, "barcodes read.", sep=" ", end="\n")
-        print("Total", len(mxtotfidf.keys()), "minimizers read.", sep=" ", end="\n")
+        print("Total", total_bx, "barcodes read.", sep=" ", end="\n", file=sys.stderr)
+        print("Total", len(mxtotfidf.keys()), "minimizers read.", sep=" ", end="\n", file=sys.stderr)
+
+        return mxtotfidf
 
     def physlr_filter_barcodes(self):
         """

--- a/physlr/physlr.py
+++ b/physlr/physlr.py
@@ -1048,11 +1048,7 @@ class Physlr:
 
         singletons = {mx for mx, n in progress(mx_counts.items()) if n < 2}
         for mxs in progress(bxtomxs.values()):
-                mxs -= singletons
-
-        mx_counts2 = Counter(mx for mxs in progress(bxtomxs.values()) for mx in mxs)
-        singletons_check = {mx for mx, n in progress(mx_counts2.items()) if n < 2}
-        print("singleton_check length is ", len(singletons_check), file=sys.stderr)
+            mxs -= singletons
 
         print(
             int(timeit.default_timer() - t0),
@@ -1070,19 +1066,17 @@ class Physlr:
         Write a minimizer to TFIDF dictionary to a pickle file.
         """
         bxtomxs = self.read_minimizers(self.args.FILES)
+        mxtobxs = self.construct_minimizers_to_barcodes(bxtomxs)
 
-        mx_counts = Counter(mx for mxs in progress(bxtomxs.values()) for mx in mxs)
+        total_bx = len(bxtomxs.keys())
+        mxtotfidf = dict((mx, math.log(total_bx/len(bxs))) for mx, bxs in mxtobxs.items())
 
-        totalBx = len(bxtomxs.keys())
-        mxtotfidf = dict((mx, math.log(totalBx/occurence)) for mx, occurence in mx_counts.items())
-        
-        fileout = open(self.args.output,"wb")
-        pickle.dump(mxtotfidf,fileout)
+        fileout = open(self.args.output, "wb")
+        pickle.dump(mxtotfidf, fileout)
         fileout.close()
-        
-        print("Total", totalBx, "barcodes read.", sep=" ", end="\n")
+
+        print("Total", total_bx, "barcodes read.", sep=" ", end="\n")
         print("Total", len(mxtotfidf.keys()), "minimizers read.", sep=" ", end="\n")
-        print("A minimizer occurs in",int(sum(mx_counts.values())/totalBx), "barcodes on average.", sep=" ", end="\n")
 
     def physlr_filter_barcodes(self):
         """
@@ -1094,8 +1088,6 @@ class Physlr:
         """
         bxtomxs = self.read_minimizers(self.args.FILES)
         Physlr.remove_singleton_minimizers(bxtomxs)
-
-        print("bxtomx length ",len(bxtomxs),sep="", file=sys.stderr)
 
         q0, q1, q2, q3, q4 = quantile(
             [0, 0.25, 0.5, 0.75, 1], (len(mxs) for mxs in bxtomxs.values()))


### PR DESCRIPTION
Calculating tf-idf of minimizers which is log(total number of barcodes/barcodes this minimizers occur). calculate_tfidf must be called after filter_barcode stage with a command similar to
```pigz -p16 -cd f1chr4.k32-w32.n100-1000.physlr.tsv.gz | env PYTHONPATH=/home/tgoktas/physlr pypy3 /home/tgoktas/physlr/bin/physlr calculate_minimizer_tfidf -o mxtotfidf.pkl -```
where ```f1chr4.k32-w32.n100-1000.physlr.tsv.gz``` is the output of filter_barcode stage.