### PR TITLE
separate --prune and --prune-bridges

### DIFF
--- a/data/Makefile
+++ b/data/Makefile
@@ -690,7 +690,7 @@ minsize=2000
 
 # Determine the maximum spanning tree.
 %.mst.tsv: %.tsv
-	$(python) $(bin)/physlr mst -V$V --prune=10 --prune-bridges=10 $< >$@
+	$(python) $(bin)/physlr mst -V$V --prune-branches=10 --prune-bridges=10 $< >$@
 
 # Separate a graph into its biconnected components by removing its cut vertices.
 %.bic.tsv: %.tsv
@@ -698,16 +698,16 @@ minsize=2000
 
 # Determine the backbone graph from the overlap TSV.
 %.backbone.tsv: %.tsv
-	$(time) $(python) $(bin)/physlr backbone-graph --prune=10 --prune-bridges=10 -s0 $< >$@
+	$(time) $(python) $(bin)/physlr backbone-graph --prune-branches=10 --prune-bridges=10 -s0 $< >$@
 
 # Determine the corrected backbone graph from the overlap TSV.
 min_path_size=200
 %.s3.backbone.tsv: %.tsv
-	$(time) $(python) $(bin)/physlr backbone-graph --prune=10 --prune-bridges=10 -s3 --min-path-size=$(min_path_size) $< >$@
+	$(time) $(python) $(bin)/physlr backbone-graph --prune-branches=10 --prune-bridges=10 -s3 --min-path-size=$(min_path_size) $< >$@
 
 # Determine the backbone path of the backbone graph.
 %.path: %.tsv
-	$(time) $(python) $(bin)/physlr backbone --prune=0 -s0 $< >$@
+	$(time) $(python) $(bin)/physlr backbone --prune-branches=0 -s0 $< >$@
 
 # Cut chimeric paths to correct misassemblies.
 %.backbone.depth.tsv: %.tsv %.backbone.path

--- a/data/Makefile
+++ b/data/Makefile
@@ -690,7 +690,7 @@ minsize=2000
 
 # Determine the maximum spanning tree.
 %.mst.tsv: %.tsv
-	$(python) $(bin)/physlr mst -V$V --prune=10 $< >$@
+	$(python) $(bin)/physlr mst -V$V --prune=10 --prune-bridges=10 $< >$@
 
 # Separate a graph into its biconnected components by removing its cut vertices.
 %.bic.tsv: %.tsv
@@ -698,12 +698,12 @@ minsize=2000
 
 # Determine the backbone graph from the overlap TSV.
 %.backbone.tsv: %.tsv
-	$(time) $(python) $(bin)/physlr backbone-graph --prune=10 -s0 $< >$@
+	$(time) $(python) $(bin)/physlr backbone-graph --prune=10 --prune-bridges=10 -s0 $< >$@
 
 # Determine the corrected backbone graph from the overlap TSV.
 min_path_size=200
 %.s3.backbone.tsv: %.tsv
-	$(time) $(python) $(bin)/physlr backbone-graph --prune=10 -s3 --min-path-size=$(min_path_size) $< >$@
+	$(time) $(python) $(bin)/physlr backbone-graph --prune=10 --prune-bridges=10 -s3 --min-path-size=$(min_path_size) $< >$@
 
 # Determine the backbone path of the backbone graph.
 %.path: %.tsv

--- a/physlr/physlr.py
+++ b/physlr/physlr.py
@@ -735,8 +735,8 @@ class Physlr:
     def determine_backbones(g):
         "Determine the backbones of the graph."
         g = g.copy()
-        if Physlr.args.prune > 0:
-            Physlr.remove_bridges(g, Physlr.args.prune)
+        if Physlr.args.prune_bridges > 0:
+            Physlr.remove_bridges(g, Physlr.args.prune_bridges)
         backbones = []
         gmst = Physlr.determine_pruned_mst(g)
         while not nx.is_empty(gmst):
@@ -1245,8 +1245,8 @@ class Physlr:
         """Determine the maximum spanning tree pruned for small branches."""
         g = self.read_graph(self.args.FILES)
         Physlr.remove_singletons(g)
-        if Physlr.args.prune > 0:
-            Physlr.remove_bridges(g, Physlr.args.prune)
+        if Physlr.args.prune_bridges > 0:
+            Physlr.remove_bridges(g, Physlr.args.prune_bridges)
         gmst = Physlr.determine_pruned_mst(g)
 
         self.write_graph(gmst, sys.stdout, self.args.graph_format)
@@ -1256,8 +1256,8 @@ class Physlr:
         """Determine the maximum spanning tree pruned for small branches."""
         g = self.read_graph(self.args.FILES)
         Physlr.remove_singletons(g)
-        if Physlr.args.prune > 0:
-            Physlr.remove_bridges(g, Physlr.args.prune)
+        if Physlr.args.prune_bridges > 0:
+            Physlr.remove_bridges(g, Physlr.args.prune_bridges)
         gmst = Physlr.determine_pruned_mst(g)
 
         print(int(timeit.default_timer() - t0), "Measuring branches.", file=sys.stderr, flush=True)
@@ -2370,8 +2370,11 @@ class Physlr:
             "--prune", action="store", dest="prune", type=int, default=10,
             help="size of the branches to be pruned [10]. set to 0 to skip prunning.")
         argparser.add_argument(
+            "--prune-bridges", action="store", dest="prune_bridges", type=int, default=0,
+            help="size of the bridges to be pruned [0]. set to 0 to skip bridge prunning.")
+        argparser.add_argument(
             "--min-branch", action="store", dest="min_branch", type=int, default=0,
-            help="split a backbone path when the alternative branch is long [0]")
+            help="split a backbone path when the alternative branch is longer than min-branch [0]. set to 0 to skip.")
         return argparser.parse_args()
 
     def __init__(self):

--- a/physlr/physlr.py
+++ b/physlr/physlr.py
@@ -2374,7 +2374,8 @@ class Physlr:
             help="size of the bridges to be pruned [0]. set to 0 to skip bridge prunning.")
         argparser.add_argument(
             "--min-branch", action="store", dest="min_branch", type=int, default=0,
-            help="split a backbone path when the alternative branch is longer than min-branch [0]. set to 0 to skip.")
+            help="split a backbone path when the alternative branch is longer than"
+                 "min-branch [0]. set to 0 to skip.")
         return argparser.parse_args()
 
     def __init__(self):

--- a/physlr/physlr.py
+++ b/physlr/physlr.py
@@ -520,7 +520,7 @@ class Physlr:
     @staticmethod
     def split_junctions_of_tree(prune_junction, gin):
         """"
-        Detect and split junctions of trees, with at least three branches larger than prune_junction.
+        Detect and split junctions of trees, with at least 3 branches larger than prune_junction.
         For each junction, keep the two incident edges with the largest weight, and remove the rest.
         """
         if prune_junction == 0:
@@ -540,7 +540,8 @@ class Physlr:
     @staticmethod
     def determine_backbones_of_trees(g, prune_junction):
         """"
-        Determine backbones of the MSTs. resolve junctions of >=3 branches of size >= prune_junction.
+        Determine backbones of the MSTs.
+        Resolve junctions of >=3 branches of size >= prune_junction.
         """
         paths = []
         for component in nx.connected_components(g):


### PR DESCRIPTION
--prune has two functionalities:
- prune branches smaller than this size.
- prune bridges smaller than this.

While the first one is used for simplifying the graph, the second is a heuristic for miss-assembly correction; so I though we need to separate them (although they still have the same value!) so I added `prune_bridges`
I am currently troubleshooting this heuristic way of correction which is causing unwanted cuts and joins; we can then modify the value in the makefile for each one or, we may end up changing the way we do the correction.
[update]: added a 3rd --prune being --prune-junctions (was --min-branch before, for splitting junctions in an MST)