### PR TITLE
physlr_remove_bridges_graph

### DIFF
--- a/data/Makefile
+++ b/data/Makefile
@@ -698,7 +698,7 @@ minsize=2000
 
 # Determine the bridge-removed graph from the overlap TSV.
 %.bridge-removed.tsv: %.tsv
-	$(time) $(python) $(bin)/physlr bridge-removed --prune-branches=10 --prune-bridges=10 -s0 $< >$@
+	$(time) $(python) $(bin)/physlr remove-bridges-graph --prune-branches=10 --prune-bridges=10 -s0 $< >$@
 
 # Determine the backbone graph from the overlap TSV.
 %.backbone.tsv: %.tsv

--- a/data/Makefile
+++ b/data/Makefile
@@ -696,6 +696,10 @@ minsize=2000
 %.bic.tsv: %.tsv
 	$(python) $(bin)/physlr biconnected-components $< >$@
 
+# Determine the bridge-removed graph from the overlap TSV.
+%.bridge-removed.tsv: %.tsv
+	$(time) $(python) $(bin)/physlr bridge-removed --prune-branches=10 --prune-bridges=10 -s0 $< >$@
+
 # Determine the backbone graph from the overlap TSV.
 %.backbone.tsv: %.tsv
 	$(time) $(python) $(bin)/physlr backbone-graph --prune-branches=10 --prune-bridges=10 -s0 $< >$@

--- a/physlr/physlr.py
+++ b/physlr/physlr.py
@@ -1272,6 +1272,15 @@ class Physlr:
         self.write_graph(gmst, sys.stdout, self.args.graph_format)
         print(int(timeit.default_timer() - t0), "Wrote the MST.", file=sys.stderr)
 
+    def physlr_bridge_removed(self):
+        """
+        Iteratively remove bridges in the MST of the graph and output the graph.
+        """
+        g = self.read_graph(self.args.FILES)
+        if Physlr.args.prune_bridges > 0:
+            Physlr.remove_bridges(g, Physlr.args.prune_bridges)
+        self.write_graph(g, sys.stdout, self.args.graph_format)
+
     def physlr_backbone(self):
         "Determine the backbone path of the graph."
         g = self.read_graph(self.args.FILES)

--- a/physlr/physlr.py
+++ b/physlr/physlr.py
@@ -1272,7 +1272,7 @@ class Physlr:
         self.write_graph(gmst, sys.stdout, self.args.graph_format)
         print(int(timeit.default_timer() - t0), "Wrote the MST.", file=sys.stderr)
 
-    def physlr_bridge_removed(self):
+    def physlr_remove_bridges_graph(self):
         """
         Iteratively remove bridges in the MST of the graph and output the graph.
         """


### PR DESCRIPTION
takes the overlap graph, removes the bridges in its MST(s) iteratively and output the bridge-removed overlap graph (not the backbone graph).
Purpose: troubleshooting the current missassembly detection method and developing a new method of correction.