### PR TITLE
read_tsv: accept graphs with no edge

### DIFF
--- a/physlr/physlr.py
+++ b/physlr/physlr.py
@@ -202,6 +202,8 @@ class Physlr:
                         print("Unexpected header:", line, file=sys.stderr)
                         sys.exit(1)
                     line = fin.readline()
+                    if not line: # a graph with no edges
+                        break
                     if Physlr.args.verbose >= 2:
                         progressbar.update(len(line))
                 xs = line.split()

--- a/physlr/physlr.py
+++ b/physlr/physlr.py
@@ -203,6 +203,8 @@ class Physlr:
                         sys.exit(1)
                     line = fin.readline()
                     if not line: # a graph with no edges
+                        print("Warning: input graph has no edges, input file:\n", 
+                              filename, file=sys.stderr)
                         break
                     if Physlr.args.verbose >= 2:
                         progressbar.update(len(line))

--- a/physlr/physlr.py
+++ b/physlr/physlr.py
@@ -203,7 +203,7 @@ class Physlr:
                         sys.exit(1)
                     line = fin.readline()
                     if not line: # a graph with no edges
-                        print("Warning: input graph has no edges, input file:\n", 
+                        print("Warning: input graph has no edges, input file:\n",
                               filename, file=sys.stderr)
                         break
                     if Physlr.args.verbose >= 2:


### PR DESCRIPTION
I was using graph format to input a list of barcodes, and I faced a "bug" in `read_tsv()`. If your graph has no edges the `read_tsv` method outputs an error message and exit. I cannot call it bug as we usually do not like graphs with no edge, but If we use this for specific usages in which graphs with no edge makes sense (like what I am doing now - to input a list of barcodes) then we need to fix this.
What do you think?