### PR TITLE
physlr.py: properly parse stlfr barcode

### DIFF
--- a/physlr/physlr.py
+++ b/physlr/physlr.py
@@ -1793,7 +1793,7 @@ class Physlr:
         for tid, path in enumerate(progress(backbones)):
             for pos, u in enumerate(path):
                 if u not in bxtomxs:
-                    u = u.split("_", 1)[0]
+                    u = u.rsplit("_", 1)[0]
                 for mx in bxtomxs[u]:
                     mxtopos.setdefault(mx, set()).add((tid, pos))
         print(


### PR DESCRIPTION
stlfr barcodes have this format `xxx_yyy_zzz`. When we remove the molecule designation tag `_0` using `u = u.split("_", 1)[0]` we only keep `xxx`, instead of `xxx_yyy_zzz`.  `u = u.rsplit("_", 1)[0]` fixes the problem by splitting on the right side