### PR TITLE
plotpaf.rmd: plot color and ideogram combined pdf

### DIFF
--- a/data/plotpaf.rmd
+++ b/data/plotpaf.rmd
@@ -175,8 +175,7 @@ pafq_ideogram <- pafq %>%
   group_by(Qname) %>%
   mutate(Colour = (Qindex + row_number()) %% 2) %>%
   ungroup() %>%
-  mutate(Colour = factor(Colour)) %>%
-  mutate(Colour = fct_recode(Colour, "Other1" = "0", "Other2" = "1"))
+  mutate(Colour = fct_recode(factor(Colour), "Other1" = "0", "Other2" = "1"))
 
 legend_breaks <- c(seq(0, 25, 1), c("Other1", "Other2"))
 

--- a/data/plotpaf.rmd
+++ b/data/plotpaf.rmd
@@ -180,7 +180,7 @@ pafq_ideogram <- pafq %>%
 
 legend_breaks <- c(seq(0, 25, 1), c("Other1", "Other2"))
 
-pafq_plot <- ggplot(pafq_ideogram) +
+ggplot(pafq_ideogram) +
   geom_rect(aes(
     xmin = Qstart, xmax = Qend,
     ymin = Qindex, ymax = Qindex + 1,
@@ -190,8 +190,7 @@ pafq_plot <- ggplot(pafq_ideogram) +
   scale_x_continuous(name = "Position", labels = unit_format(unit = "M", scale = 1e-6)) +
   scale_y_reverse(name = "Chromosome (Query)",
                   breaks = 0.5 + seq_len(nlevels(pafq$Qname)),
-                  labels = levels(pafq$Qname))
-pafq_plot  <- pafq_plot +
+                  labels = levels(pafq$Qname)) +
   geom_rect(data=pafq[!(pafq$Tname=="Other"),], aes(
     xmin = Qstart, xmax = Qend,
     ymin = Qindex, ymax = Qindex + 1,
@@ -204,7 +203,6 @@ pafq_plot  <- pafq_plot +
   theme_bw() +
   guides(fill = guide_legend(ncol = 1)) +
   labs(caption = input_paf)
-pafq_plot
 ```
 
 ```{r save-plot-q}

--- a/data/plotpaf.rmd
+++ b/data/plotpaf.rmd
@@ -165,23 +165,19 @@ pafq_lumped <- paf_chained %>%
 	mutate(Tname = fct_inorder(fct_lump(Tname, n = 26, w = Barcodes, ties.method = "first")))
 
 pal <- setNames(alphabet_colours, pafq_lumped$Tname %>% setdiff("Other") %>% unique())
-pal["Other"] <- "#c0c0c0"
+pal["Other1"] <- "#808080"
+pal["Other2"] <- "#c0c0c0"
 
 pafq <- pafq_lumped %>% arrange(desc(Qlength), Qname, Qstart, Barcodes)
 
 pafq_ideogram <- pafq %>%
   arrange(desc(Qlength), Qname, Qstart, Barcodes) %>%
   group_by(Qname) %>%
-  mutate(Colour = (Qindex + row_number()) %% 2 + 26) %>%
+  mutate(Colour = (Qindex + row_number()) %% 2) %>%
   ungroup() %>%
   mutate(Colour = factor(Colour))
-pafq_ideogram$Colour <- as.character(pafq_ideogram$Colour)
-pafq_ideogram$Colour[pafq_ideogram$Colour == "26"] <- "Other1"
-pafq_ideogram$Colour[pafq_ideogram$Colour == "27"] <- "Other2"
-pafq_ideogram$Colour <- as.factor(pafq_ideogram$Colour)
-pal <- setNames(alphabet_colours, pafq_lumped$Tname %>% setdiff("Other") %>% unique())
-pal["Other1"] <- "#808080"
-pal["Other2"] <- "#c0c0c0"
+pafq_ideogram <- mutate(pafq_ideogram, Colour = fct_recode(Colour, "Other1" = "0", "Other2" = "1"))
+
 legend_breaks <- c(seq(0, 25, 1), c("Other1", "Other2"))
 
 pafq_plot <- ggplot(pafq_ideogram) +

--- a/data/plotpaf.rmd
+++ b/data/plotpaf.rmd
@@ -228,6 +228,51 @@ ggsave(pdf_filename, width = 8, height = 10, units = "in")
 cat(pdf_filename)
 ```
 
+# Reference Coverage (Colour for 25 largest backbones, ideogram for remaining)
+```{r plot-q-ideogram, fig.width=8, fig.height=10}
+pafq_ideogram <- pafq %>%
+  arrange(desc(Qlength), Qname, Qstart, Barcodes) %>%
+  group_by(Qname) %>%
+  mutate(Colour = (Qindex + row_number()) %% 2 + 26) %>%
+  ungroup() %>%
+  mutate(Colour = factor(Colour))
+pal2 <- setNames(alphabet_colours, pafq_lumped$Tname %>% setdiff("Other") %>% unique())
+pal2["26"] <- "#808080"
+pal2["27"] <- "#c0c0c0"
+
+plot <- ggplot(pafq_ideogram) +
+  geom_rect(aes(
+    xmin = Qstart, xmax = Qend,
+    ymin = Qindex, ymax = Qindex + 1,
+    fill = Colour)) +
+  geom_point(aes(x = Qlength, y = 0.5 + Qindex),
+             data = distinct(pafq, Qlength, Qindex)) +
+  scale_x_continuous(name = "Position", labels = unit_format(unit = "M", scale = 1e-6)) +
+  scale_y_reverse(name = "Chromosome (Query)",
+                  breaks = 0.5 + seq_len(nlevels(pafq$Qname)),
+                  labels = levels(pafq$Qname)) +
+  scale_fill_manual(name = "Target", values = pal2) +
+  theme_bw() +
+  guides(fill = guide_legend(ncol = 1)) +
+  labs(caption = input_paf)
+plot  <- plot +
+  geom_rect(data=pafq[!(pafq$Tname=="Other"),], aes(
+    xmin = Qstart, xmax = Qend,
+    ymin = Qindex, ymax = Qindex + 1,
+    fill = Tname)) +
+  geom_rect(data = gaps, aes(
+	xmin = Start, xmax = End,
+	ymin = Index + 0.45, ymax = Index + 0.55),
+	fill = "darkred")
+plot
+```
+
+```{r save-plot-q-ideogram}
+pdf_filename <- paste0(input_paf, ".q+ideo.pdf")
+ggsave(pdf_filename, width = 8, height = 10, units = "in")
+cat(pdf_filename)
+```
+
 # Dot plot
 ```{r plot-dot, fig.width=6, fig.height=24}
 tlength_threshold <- 200

--- a/data/plotpaf.rmd
+++ b/data/plotpaf.rmd
@@ -175,8 +175,8 @@ pafq_ideogram <- pafq %>%
   group_by(Qname) %>%
   mutate(Colour = (Qindex + row_number()) %% 2) %>%
   ungroup() %>%
-  mutate(Colour = factor(Colour))
-pafq_ideogram <- mutate(pafq_ideogram, Colour = fct_recode(Colour, "Other1" = "0", "Other2" = "1"))
+  mutate(Colour = factor(Colour)) %>%
+  mutate(Colour = fct_recode(Colour, "Other1" = "0", "Other2" = "1"))
 
 legend_breaks <- c(seq(0, 25, 1), c("Other1", "Other2"))
 

--- a/data/plotpaf.rmd
+++ b/data/plotpaf.rmd
@@ -253,12 +253,6 @@ ggsave(pdf_filename, width = 8, height = 10, units = "in")
 cat(pdf_filename)
 ```
 
-```{r save-plot-q-ideogram}
-pdf_filename <- paste0(input_paf, ".q+ideo.pdf")
-ggsave(pdf_filename, width = 8, height = 10, units = "in")
-cat(pdf_filename)
-```
-
 # Dot plot
 ```{r plot-dot, fig.width=6, fig.height=24}
 tlength_threshold <- 200

--- a/data/plotpaf.rmd
+++ b/data/plotpaf.rmd
@@ -169,21 +169,46 @@ pal["Other"] <- "#c0c0c0"
 
 pafq <- pafq_lumped %>% arrange(desc(Qlength), Qname, Qstart, Barcodes)
 
-ggplot(pafq) +
-	geom_rect(aes(
-		xmin = Qstart, xmax = Qend,
-		ymin = Qindex, ymax = Qindex + 1,
-		fill = Tname)) +
-	geom_point(aes(x = Qlength, y = 0.5 + Qindex),
-		data = distinct(pafq, Qlength, Qindex)) +
-	scale_x_continuous(name = "Position", labels = unit_format(unit = "M", scale = 1e-6)) +
-	scale_y_reverse(name = "Chromosome (Query)",
-		breaks = 0.5 + seq_len(nlevels(pafq$Qname)),
-		labels = levels(pafq$Qname)) +
-	scale_fill_manual(name = "Target", values = pal) +
-	theme_bw() +
-	guides(fill = guide_legend(ncol = 1)) +
-	labs(caption = input_paf)
+pafq_ideogram <- pafq %>%
+  arrange(desc(Qlength), Qname, Qstart, Barcodes) %>%
+  group_by(Qname) %>%
+  mutate(Colour = (Qindex + row_number()) %% 2 + 26) %>%
+  ungroup() %>%
+  mutate(Colour = factor(Colour))
+pafq_ideogram$Colour <- as.character(pafq_ideogram$Colour)
+pafq_ideogram$Colour[pafq_ideogram$Colour == "26"] <- "Other1"
+pafq_ideogram$Colour[pafq_ideogram$Colour == "27"] <- "Other2"
+pafq_ideogram$Colour <- as.factor(pafq_ideogram$Colour)
+pal <- setNames(alphabet_colours, pafq_lumped$Tname %>% setdiff("Other") %>% unique())
+pal["Other1"] <- "#808080"
+pal["Other2"] <- "#c0c0c0"
+legend_breaks <- c(seq(0, 25, 1), c("Other1", "Other2"))
+
+pafq_plot <- ggplot(pafq_ideogram) +
+  geom_rect(aes(
+    xmin = Qstart, xmax = Qend,
+    ymin = Qindex, ymax = Qindex + 1,
+    fill = Colour)) +
+  geom_point(aes(x = Qlength, y = 0.5 + Qindex),
+             data = distinct(pafq, Qlength, Qindex)) +
+  scale_x_continuous(name = "Position", labels = unit_format(unit = "M", scale = 1e-6)) +
+  scale_y_reverse(name = "Chromosome (Query)",
+                  breaks = 0.5 + seq_len(nlevels(pafq$Qname)),
+                  labels = levels(pafq$Qname))
+pafq_plot  <- pafq_plot +
+  geom_rect(data=pafq[!(pafq$Tname=="Other"),], aes(
+    xmin = Qstart, xmax = Qend,
+    ymin = Qindex, ymax = Qindex + 1,
+    fill = Tname)) +
+  geom_rect(data = gaps, aes(
+	xmin = Start, xmax = End,
+	ymin = Index + 0.45, ymax = Index + 0.55),
+	fill = "darkred") +
+  scale_fill_manual(name = "Target", values = pal, breaks = legend_breaks) +
+  theme_bw() +
+  guides(fill = guide_legend(ncol = 1)) +
+  labs(caption = input_paf)
+pafq_plot
 ```
 
 ```{r save-plot-q}
@@ -226,45 +251,6 @@ ggplot(paf_ideogram) +
 pdf_filename <- paste0(input_paf, ".ideo.pdf")
 ggsave(pdf_filename, width = 8, height = 10, units = "in")
 cat(pdf_filename)
-```
-
-# Reference Coverage (Colour for 25 largest backbones, ideogram for remaining)
-```{r plot-q-ideogram, fig.width=8, fig.height=10}
-pafq_ideogram <- pafq %>%
-  arrange(desc(Qlength), Qname, Qstart, Barcodes) %>%
-  group_by(Qname) %>%
-  mutate(Colour = (Qindex + row_number()) %% 2 + 26) %>%
-  ungroup() %>%
-  mutate(Colour = factor(Colour))
-pal2 <- setNames(alphabet_colours, pafq_lumped$Tname %>% setdiff("Other") %>% unique())
-pal2["26"] <- "#808080"
-pal2["27"] <- "#c0c0c0"
-
-plot <- ggplot(pafq_ideogram) +
-  geom_rect(aes(
-    xmin = Qstart, xmax = Qend,
-    ymin = Qindex, ymax = Qindex + 1,
-    fill = Colour)) +
-  geom_point(aes(x = Qlength, y = 0.5 + Qindex),
-             data = distinct(pafq, Qlength, Qindex)) +
-  scale_x_continuous(name = "Position", labels = unit_format(unit = "M", scale = 1e-6)) +
-  scale_y_reverse(name = "Chromosome (Query)",
-                  breaks = 0.5 + seq_len(nlevels(pafq$Qname)),
-                  labels = levels(pafq$Qname)) +
-  scale_fill_manual(name = "Target", values = pal2) +
-  theme_bw() +
-  guides(fill = guide_legend(ncol = 1)) +
-  labs(caption = input_paf)
-plot  <- plot +
-  geom_rect(data=pafq[!(pafq$Tname=="Other"),], aes(
-    xmin = Qstart, xmax = Qend,
-    ymin = Qindex, ymax = Qindex + 1,
-    fill = Tname)) +
-  geom_rect(data = gaps, aes(
-	xmin = Start, xmax = End,
-	ymin = Index + 0.45, ymax = Index + 0.55),
-	fill = "darkred")
-plot
 ```
 
 ```{r save-plot-q-ideogram}


### PR DESCRIPTION
For the `x.paf.gz.q.pdf`, the smallest backbones are clumped together as other and isn't really helpful when we want to see how many backbone are in that one gray rectangle in the plot. 

This PR adds a new plot where I plot the backbones on the reference using an ideogram colour scheme. Then I overlay it with the largest backbones using the 25 colour scheme. This will achieve effectively the same result as `x.paf.gz.q.pdf` but instead of solid gray backbones for others, we get alternating gray in those sections