### PR TITLE
Makefile: add rule to differentiate  %.qpos.paf.gz.pdf and %.paf.gz.pdf

### DIFF
--- a/data/Makefile
+++ b/data/Makefile
@@ -1092,9 +1092,7 @@ mol_strategy=bc
 
 # Plot a PAF file.
 %.paf.gz.pdf: %.paf.gz
-	echo > dummy.bed; \
-	Rscript -e 'rmarkdown::render("$(physlr_path)/data/plotpaf.rmd", "html_document", "$*.paf.gz.html", knit_root_dir="$(PWD)", output_dir="$(PWD)", params=list(input_paf="$<", gap_bed="dummy.bed"))'; \
-	rm dummy.bed
+	Rscript -e 'rmarkdown::render("$(physlr_path)/data/plotpaf.rmd", "html_document", "$*.paf.gz.html", knit_root_dir="$(PWD)", output_dir="$(PWD)", params=list(input_paf="$<", gap_bed="dummy.bed"))'
 
 # Compare assembly metrics.
 %.quast.html: %.quast.tsv

--- a/data/Makefile
+++ b/data/Makefile
@@ -1086,9 +1086,15 @@ mol_strategy=bc
 %.bed.pdf: %.bed
 	Rscript -e 'rmarkdown::render("$(physlr_path)/data/plotbed.rmd", "html_document", "$*.bed.html", knit_root_dir="$(PWD)", output_dir="$(PWD)", params=list(input_bed="$<"))'
 
-# Plot a PAF file.
-%.paf.gz.pdf: %.paf.gz $(name)/$(ref).fa.gap.bed
+# Plot a qpos PAF file.
+%.qpos.paf.gz.pdf: %.qpos.paf.gz $(name)/$(ref).fa.gap.bed
 	Rscript -e 'rmarkdown::render("$(physlr_path)/data/plotpaf.rmd", "html_document", "$*.paf.gz.html", knit_root_dir="$(PWD)", output_dir="$(PWD)", params=list(input_paf="$<", gap_bed="$(name)/$(ref).fa.gap.bed"))'
+
+# Plot a PAF file.
+%.paf.gz.pdf: %.paf.gz
+	echo > dummy.bed; \
+	Rscript -e 'rmarkdown::render("$(physlr_path)/data/plotpaf.rmd", "html_document", "$*.paf.gz.html", knit_root_dir="$(PWD)", output_dir="$(PWD)", params=list(input_paf="$<", gap_bed="dummy.bed"))'; \
+	rm dummy.bed
 
 # Compare assembly metrics.
 %.quast.html: %.quast.tsv

--- a/data/Makefile
+++ b/data/Makefile
@@ -1092,7 +1092,7 @@ mol_strategy=bc
 
 # Plot a PAF file.
 %.paf.gz.pdf: %.paf.gz
-	Rscript -e 'rmarkdown::render("$(physlr_path)/data/plotpaf.rmd", "html_document", "$*.paf.gz.html", knit_root_dir="$(PWD)", output_dir="$(PWD)", params=list(input_paf="$<", gap_bed="dummy.bed"))'
+	Rscript -e 'rmarkdown::render("$(physlr_path)/data/plotpaf.rmd", "html_document", "$*.paf.gz.html", knit_root_dir="$(PWD)", output_dir="$(PWD)", params=list(input_paf="$<"))'
 
 # Compare assembly metrics.
 %.quast.html: %.quast.tsv

--- a/data/plotpaf.rmd
+++ b/data/plotpaf.rmd
@@ -4,7 +4,7 @@ author: Shaun Jackman
 params:
   gap_bed:
     label: "BED file of gaps"
-    value: "gap.bed"
+    value: ""
     input: text
   input_paf:
     label: "Input PAF file"
@@ -63,11 +63,14 @@ qname_qindex <- paf %>%
 	transmute(Name = as.character(Qname), Index = Qindex) %>%
 	distinct() %>%
 	arrange(Index)
-
-gaps <- read_tsv(gap_bed, col_names = c("Name", "Start", "End", "Label"), col_types = "ciic") %>%
-	filter(End - Start >= gap_threshold) %>%
-	left_join(qname_qindex, by = "Name") %>%
-	drop_na()
+if (gap_bed == ""){
+	gaps <- tibble( Name=character(), Start=integer(), End=integer(), Label=character(), Index=double())
+} else {
+	gaps <- read_tsv(gap_bed, col_names = c("Name", "Start", "End", "Label"), col_types = "ciic") %>%
+		filter(End - Start >= gap_threshold) %>%
+		left_join(qname_qindex, by = "Name") %>%
+		drop_na()
+}
 ```
 
 # Chain alignments


### PR DESCRIPTION
So previously, there are no distinctions between plotting `%.qpos.paf.gz.pdf` and `%.paf.gz.pdf`. This has an unintended consequence with the ideogram output. The ideogram output uses the `gap.bed` to plot gaps in the reference. The problem is these positions are in chromosome positions plotting against minimizer positions. The result is the following:
Using gap.bed for %.paf.gz.pdf:
![Screenshot from 2019-10-25 14-43-01](https://user-images.githubusercontent.com/34543031/67606354-fce98300-f735-11e9-9803-97e207f2a7a7.png)

By generating a dummy file, I can resolve the problem
Using dummy.bed for %.paf.gz.pdf:
![Screenshot from 2019-10-25 14-43-59](https://user-images.githubusercontent.com/34543031/67606359-fe1ab000-f735-11e9-87a9-00fbd00d02f1.png)
