### PR TITLE
physlr: improve path_to_fasta

### DIFF
--- a/physlr/physlr.py
+++ b/physlr/physlr.py
@@ -2192,19 +2192,36 @@ class Physlr:
         num_scaffolds = 0
         num_contigs = 0
         num_bases = 0
+
+        unused_seqs = {name[0:-1] for path in paths for name in path if name[-1] == "."}
+
+        gaps = ("N" * self.args.gap_size)
+
         for path in progress(paths):
-            # Remove unoriented sequences.
-            path = [name for name in path if name[-1] != "."]
             if not path:
                 continue
 
-            seq = "NNNNNNNNNN".join(Physlr.get_oriented_sequence(seqs, name) for name in path)
+            seq = gaps.join(Physlr.get_oriented_sequence(seqs, name)
+                            if name[-1] != "." else ("N" * len(seqs[name[0:-1]]))
+                            for name in path)
+
             if len(seq) < self.args.min_length:
                 continue
             num_scaffolds += 1
             print(f">{str(num_scaffolds).zfill(7)} LN:i:{len(seq)} xn:i:{len(path)}\n{seq}")
             num_contigs += len(path)
             num_bases += len(seq)
+
+        for name in seqs:
+            if name in unused_seqs:
+                seq = seqs[name]
+                if len(seq) < self.args.min_length:
+                    continue
+                num_scaffolds += 1
+                print(f">{str(num_scaffolds).zfill(7)} LN:i:{len(seq)} xn:i:{1}\n{seq}")
+                num_contigs += 1
+                num_bases += len(seq)
+
         print(
             int(timeit.default_timer() - t0),
             f"Wrote {num_bases} bases in {num_contigs} contigs in {num_scaffolds} scaffolds.",
@@ -2437,6 +2454,9 @@ class Physlr:
             "--prune-junctions", action="store", dest="prune_junctions", type=int, default=0,
             help="split a backbone path when the alternative branch is longer than"
                  "prune-junctions [0]. set to 0 to skip.")
+        argparser.add_argument(
+            "--gap-size", action="store", dest="gap_size", type=int, default=100,
+            help="gap size used in scaffolding [0].")
         return argparser.parse_args()
 
     def __init__(self):

--- a/physlr/physlr.py
+++ b/physlr/physlr.py
@@ -2195,7 +2195,7 @@ class Physlr:
 
         unused_seqs = {name[0:-1] for path in paths for name in path if name[-1] == "."}
 
-        gaps = ("N" * self.args.gap_size)
+        gaps = "N" * self.args.gap_size
 
         for path in progress(paths):
             if not path:
@@ -2456,7 +2456,7 @@ class Physlr:
                  "prune-junctions [0]. set to 0 to skip.")
         argparser.add_argument(
             "--gap-size", action="store", dest="gap_size", type=int, default=100,
-            help="gap size used in scaffolding [0].")
+            help="gap size used in scaffolding [100].")
         return argparser.parse_args()
 
     def __init__(self):

--- a/physlr/physlr.py
+++ b/physlr/physlr.py
@@ -2193,7 +2193,7 @@ class Physlr:
         num_contigs = 0
         num_bases = 0
 
-        unused_seqs = {name[0:-1] for path in paths for name in path if name[-1] == "."}
+        used_seqs = {name[0:-1] for path in paths for name in path if name[-1] != "."}
 
         gaps = "N" * self.args.gap_size
 
@@ -2213,7 +2213,7 @@ class Physlr:
             num_bases += len(seq)
 
         for name in seqs:
-            if name in unused_seqs:
+            if name not in used_seqs:
                 seq = seqs[name]
                 if len(seq) < self.args.min_length:
                     continue


### PR DESCRIPTION
Improve path to fasta by inserting more Ns, and insert the equivalent number of bases as N when we have un-oriented pieces.

Change include:

- Default gap-size is 100 Ns (better results with Quast). Can be changed by user.

-  Print un-oriented contigs as Ns instead of removing them altogether (better results with Quast).

- Print unmapped contigs to avoid genome % drops (better results with Quast).