### PR TITLE
indexlr: set thread limit to 48 when supplying a Bloom filter

### DIFF
--- a/src/physlr-indexlr.cc
+++ b/src/physlr-indexlr.cc
@@ -141,10 +141,10 @@ main(int argc, char* argv[])
 			break;
 		case 't':
 			t = strtoul(optarg, &end, 10);
-			if (t > 5) {
-				t = 5;
+			if (t > 48) {
+				t = 48;
 				std::cerr << progname
-				          << ": Using more than 5 threads does not scale, reverting to 5.\n";
+				          << ": Using more than 48 threads does not scale, reverting to 48.\n";
 			}
 			break;
 		case 'r': {

--- a/src/physlr-indexlr.cc
+++ b/src/physlr-indexlr.cc
@@ -141,11 +141,6 @@ main(int argc, char* argv[])
 			break;
 		case 't':
 			t = strtoul(optarg, &end, 10);
-			if (t > 48) {
-				t = 48;
-				std::cerr << progname
-				          << ": Using more than 48 threads does not scale, reverting to 48.\n";
-			}
 			break;
 		case 'r': {
 			withRepeat = true;
@@ -172,6 +167,11 @@ main(int argc, char* argv[])
 		default:
 			exit(EXIT_FAILURE);
 		}
+	}
+	if (t > 5 && !(withSolid || withRepeat)) {
+		t = 5;
+		std::cerr << progname << ": Using more than 5 threads does not scale, reverting to 5."
+		          << std::endl;
 	}
 	std::vector<std::string> infiles(&argv[optind], &argv[argc]);
 	if (argc < 2) {

--- a/src/physlr-indexlr.cc
+++ b/src/physlr-indexlr.cc
@@ -172,7 +172,7 @@ main(int argc, char* argv[])
 		t = 5;
 		std::cerr
 		    << progname
-		    << ": Using more than 5 threads wihtout Bloom filter does not scale, reverting to 5."
+		    << ": Using more than 5 threads without Bloom filter does not scale, reverting to 5."
 		    << std::endl;
 	} else {
 		if (t > 48) {

--- a/src/physlr-indexlr.cc
+++ b/src/physlr-indexlr.cc
@@ -170,8 +170,17 @@ main(int argc, char* argv[])
 	}
 	if (t > 5 && !(withSolid || withRepeat)) {
 		t = 5;
-		std::cerr << progname << ": Using more than 5 threads does not scale, reverting to 5."
-		          << std::endl;
+		std::cerr
+		    << progname
+		    << ": Using more than 5 threads wihtout Bloom filter does not scale, reverting to 5."
+		    << std::endl;
+	} else {
+		if (t > 48) {
+			std::cerr
+			    << progname
+			    << ": Using more than 48 threads with Bloom filter does not scale, reverting to 48."
+			    << std::endl;
+		}
 	}
 	std::vector<std::string> infiles(&argv[optind], &argv[argc]);
 	if (argc < 2) {


### PR DESCRIPTION
With the inclusion of the Bloom filter, there is more work to be done so performance will scale with more than 5 threads.