### PR TITLE
Deal with backbone with only un-oriented sequences

### DIFF
--- a/data/Makefile
+++ b/data/Makefile
@@ -1012,7 +1012,7 @@ mol_strategy=bc
 
 # Produce sequences in FASTA format from paths.
 %.$(draft).n10.sort.best.bed.path.fa: $(draft).fa %.$(draft).n10.sort.best.bed.path
-	$(time) $(python) $(bin)/physlr path-to-fasta --min-length=3000 $^ >$@
+	$(time) $(python) $(bin)/physlr path-to-fasta --min-length=0 $^ >$@
 
 # Convert a PAF file to a BED file.
 %.paf.bed: %.paf.gz

--- a/physlr/physlr.py
+++ b/physlr/physlr.py
@@ -2201,20 +2201,16 @@ class Physlr:
             if not path:
                 continue
 
-            if len(path) == 1:
-                if path[0][-1] == ".":
-                    path[0] = path[0][:-1] + "+"
-            else:
-                all_unoriented = True
-                longest_seq = 0
-                for idx, name in enumerate(path):
-                    if name[-1] != ".":
-                        all_unoriented = False
-                        break
-                    if len(name) > len(path[longest_seq]):
-                        longest_seq = idx
-                if all_unoriented:
-                    path[longest_seq] = path[longest_seq][:-1] + "+"
+            all_unoriented = True
+            longest_seq = 0
+            for idx, name in enumerate(path):
+                if name[-1] != ".":
+                    all_unoriented = False
+                    break
+                if len(name) > len(path[longest_seq]):
+                    longest_seq = idx
+            if all_unoriented:
+                path[longest_seq] = path[longest_seq][:-1] + "+"
 
             seq = gaps.join(Physlr.get_oriented_sequence(seqs, name)
                             if name[-1] != "." else ("N" * len(seqs[name[0:-1]]))

--- a/physlr/physlr.py
+++ b/physlr/physlr.py
@@ -2198,18 +2198,11 @@ class Physlr:
         gaps = "N" * self.args.gap_size
 
         for path in progress(paths):
-            all_unoriented = True
-            longest_seq = 0
-            for idx, name in enumerate(path):
-                if name[-1] != ".":
-                    all_unoriented = False
-                    break
-                if len(name) > len(path[longest_seq]):
-                    longest_seq = idx
-            if all_unoriented:
-                path = None
-
             if not path:
+                continue
+
+            all_unoriented = all([name[-1] == "." for name in path])
+            if all_unoriented:
                 continue
 
             seq = gaps.join(Physlr.get_oriented_sequence(seqs, name)

--- a/physlr/physlr.py
+++ b/physlr/physlr.py
@@ -2198,9 +2198,6 @@ class Physlr:
         gaps = "N" * self.args.gap_size
 
         for path in progress(paths):
-            if not path:
-                continue
-
             all_unoriented = True
             longest_seq = 0
             for idx, name in enumerate(path):
@@ -2210,7 +2207,10 @@ class Physlr:
                 if len(name) > len(path[longest_seq]):
                     longest_seq = idx
             if all_unoriented:
-                path[longest_seq] = path[longest_seq][:-1] + "+"
+                path = None
+
+            if not path:
+                continue
 
             seq = gaps.join(Physlr.get_oriented_sequence(seqs, name)
                             if name[-1] != "." else ("N" * len(seqs[name[0:-1]]))

--- a/physlr/physlr.py
+++ b/physlr/physlr.py
@@ -2195,13 +2195,26 @@ class Physlr:
         num_contigs = 0
         num_bases = 0
 
-        used_seqs = {name[0:-1] for path in paths for name in path if name[-1] != "."}
-
         gaps = "N" * self.args.gap_size
 
         for path in progress(paths):
             if not path:
                 continue
+
+            if len(path) == 1:
+                if path[0][-1] == ".":
+                    path[0] = path[0][:-1] + "+"
+            else:
+                all_unoriented = True
+                longest_seq = 0
+                for idx, name in enumerate(path):
+                    if name[-1] != ".":
+                        all_unoriented = False
+                        break
+                    if len(name) > len(path[longest_seq]):
+                        longest_seq = idx
+                if all_unoriented:
+                    path[longest_seq] = path[longest_seq][:-1] + "+"
 
             seq = gaps.join(Physlr.get_oriented_sequence(seqs, name)
                             if name[-1] != "." else ("N" * len(seqs[name[0:-1]]))
@@ -2213,6 +2226,8 @@ class Physlr:
             print(f">{str(num_scaffolds).zfill(7)} LN:i:{len(seq)} xn:i:{len(path)}\n{seq}")
             num_contigs += len(path)
             num_bases += len(seq)
+
+        used_seqs = {name[0:-1] for path in paths for name in path if name[-1] != "."}
 
         for name in seqs:
             if name not in used_seqs:


### PR DESCRIPTION
There are edges cases where a backbone consist of only un-oriented sequences. This PR contains code to deal with these exceptions, by taking the longest sequence within the backbone and assigning it a positive orientation