### PR TITLE
Filter overlap edges with % of edges instead of weight

### DIFF
--- a/data/Makefile
+++ b/data/Makefile
@@ -928,18 +928,6 @@ g=$(shell awk '{x += $$2} END{print x}' $(name)/$(ref).fa.fai)
 %.cn.tsv: %.tsv
 	$(python) $(bin)/physlr common-neighbours $< >$@
 
-# Filter 10% of lowest weighted edges using python.
-%.n10.tsv: %.tsv
-	$(time) $(python) $(bin)/physlr filter-overlap --minimizer-overlap 10 $< >$@
-
-# Filter 20% of lowest weighted edges using python.
-%.n20.tsv: %.tsv
-	$(time) $(python) $(bin)/physlr filter-overlap --minimizer-overlap 20 $< >$@
-
-# Filter 50% of lowest weighted edges using python.
-%.n50.tsv: %.tsv
-	$(time) $(python) $(bin)/physlr filter-overlap --minimizer-overlap 50 $< >$@
-
 # Filter n% of lowest weighted edges using python.
 %.n$n.tsv: %.tsv
 	$(time) $(python) $(bin)/physlr filter-overlap --minimizer-overlap $n $< >$@

--- a/data/Makefile
+++ b/data/Makefile
@@ -928,25 +928,21 @@ g=$(shell awk '{x += $$2} END{print x}' $(name)/$(ref).fa.fai)
 %.cn.tsv: %.tsv
 	$(python) $(bin)/physlr common-neighbours $< >$@
 
-# Filter edges n >= 10 using Miller.
+# Filter 10% of lowest weighted edges using python.
 %.n10.tsv: %.tsv
-	mlr --tsvlite filter '$$n >= 10' $< >$@
+	$(time) $(python) $(bin)/physlr filter-overlap --minimizer-overlap 10 $< >$@
 
-# Filter edges n >= 20 using Miller.
+# Filter 20% of lowest weighted edges using python.
 %.n20.tsv: %.tsv
-	mlr --tsvlite filter '$$n >= 20' $< >$@
+	$(time) $(python) $(bin)/physlr filter-overlap --minimizer-overlap 20 $< >$@
 
-# Filter edges n >= 50 using Miller.
+# Filter 50% of lowest weighted edges using python.
 %.n50.tsv: %.tsv
-	mlr --tsvlite filter '$$n >= 50' $< >$@
+	$(time) $(python) $(bin)/physlr filter-overlap --minimizer-overlap 50 $< >$@
 
-# Filter edges n >= 100 using Miller.
-%.n100.tsv: %.tsv
-	mlr --tsvlite filter '$$n >= 100' $< >$@
-
-# Filter edges by n using Miller.
+# Filter n% of lowest weighted edges using python.
 %.n$n.tsv: %.tsv
-	mlr --tsvlite filter '$$n >= $n' $< >$@
+	$(time) $(python) $(bin)/physlr filter-overlap --minimizer-overlap $n $< >$@
 
 # Keep the best edges of each vertex.
 %.best$(bestn).tsv: %.tsv

--- a/physlr/physlr.py
+++ b/physlr/physlr.py
@@ -1242,7 +1242,6 @@ class Physlr:
     def physlr_filter_overlap(self):
         "Read a Physlr overlap graph and filter edges."
 
-        edges = {}
         edge_weight = []
 
         at_edges = False

--- a/physlr/physlr.py
+++ b/physlr/physlr.py
@@ -1245,19 +1245,18 @@ class Physlr:
         edge_weight = []
 
         at_edges = False
-        overlap_input = open(self.args.FILES[0], "r")
         print(int(timeit.default_timer() - t0), "Processing Nodes", file=sys.stderr)
-        for line in overlap_input:
-            if at_edges:
-                columns = line.rstrip().split("\t")
-                edge_weight.append(int(columns[2]))
-            else:
-                print(line.rstrip())
-                if not line.strip():
-                    print(next(overlap_input).rstrip())
-                    print(int(timeit.default_timer() - t0), "Processing Edges", file=sys.stderr)
-                    at_edges = True
-        overlap_input.close()
+        with open(self.args.FILES[0], "r") as overlap_input:
+            for line in overlap_input:
+                if at_edges:
+                    columns = line.rstrip().split("\t")
+                    edge_weight.append(int(columns[2]))
+                else:
+                    print(line.rstrip())
+                    if not line.strip():
+                        print(next(overlap_input).rstrip())
+                        print(int(timeit.default_timer() - t0), "Processing Edges", file=sys.stderr)
+                        at_edges = True
 
         print(int(timeit.default_timer() - t0), "Sorting Edges", file=sys.stderr)
         edge_weight.sort()
@@ -1267,17 +1266,16 @@ class Physlr:
         print(int(timeit.default_timer() - t0), "Filtering Edges", file=sys.stderr)
         print(int(timeit.default_timer() - t0), "Lower Threshold", lower_threshold, file=sys.stderr)
         at_edges = False
-        overlap_input = open(self.args.FILES[0], "r")
-        for line in overlap_input:
-            if at_edges:
-                columns = line.rstrip().split("\t")
-                if int(columns[2]) > lower_threshold:
-                    print(line.rstrip())
-            else:
-                if not line.strip():
-                    at_edges = True
-                    next(overlap_input)
-        overlap_input.close()
+        with open(self.args.FILES[0], "r") as overlap_input:
+            for line in overlap_input:
+                if at_edges:
+                    columns = line.rstrip().split("\t")
+                    if int(columns[2]) > lower_threshold:
+                        print(line.rstrip())
+                else:
+                    if not line.strip():
+                        at_edges = True
+                        next(overlap_input)
 
     def physlr_degree(self):
         "Print the degree of each vertex."


### PR DESCRIPTION
As edge weight can vary between data sets, it becomes quite difficult to find a good default value to use for all data sets. By filtering % of edges, we make the numbers more applicable for one data set to the other and I've managed to find good default values for both stLFR and 10X data set for edge filtering.