### PR TITLE
Permit float values in paf file

### DIFF
--- a/physlr/physlr.py
+++ b/physlr/physlr.py
@@ -110,7 +110,7 @@ class Physlr:
                     paf.append((
                         qname, int(qlength), int(qstart), int(qend), orientation,
                         tname, int(tlength), int(tstart), int(tend),
-                        int(score), int(length), int(mapq)))
+                        int(score), int(length), float(mapq)))
                 if Physlr.args.verbose >= 2:
                     progressbar.close()
             print(int(timeit.default_timer() - t0), "Read", filename, file=sys.stderr)


### PR DESCRIPTION
Post chaining paf files can have float mapq and the code as it is will break