### PR TITLE
chainpaf hotfix

### DIFF
--- a/data/bin/chainpaf
+++ b/data/bin/chainpaf
@@ -74,7 +74,7 @@ paf_chained <- paf_segmented %>%
 		Tend = max(Tend),
 		Matches = sum(Matches),
 		Length = sum(Length),
-		Mapq = median(Mapq),
+		Mapq = as.integer(median(Mapq)),
 		Barcodes = n()) %>%
 	ungroup() %>%
 	select(Qname, Qlength, Qstart, Qend, Orientation,

--- a/physlr/physlr.py
+++ b/physlr/physlr.py
@@ -110,7 +110,7 @@ class Physlr:
                     paf.append((
                         qname, int(qlength), int(qstart), int(qend), orientation,
                         tname, int(tlength), int(tstart), int(tend),
-                        int(score), int(length), float(mapq)))
+                        int(score), int(length), int(mapq)))
                 if Physlr.args.verbose >= 2:
                     progressbar.close()
             print(int(timeit.default_timer() - t0), "Read", filename, file=sys.stderr)


### PR DESCRIPTION
Context:
chainpaf produced float mapq values which was incompatible with the `read_paf` function. In a previous PR, we adjust the readpaf code to allow float mapq values. This was not the correct fix as the mapq value itself shouldn't be a float. This PR reverts the ability to read float mapq values and modifies chainpaf to only output int mapq values.