### PR TITLE
physlr-make: use k-mer repetitive threshold instead of 100

### DIFF
--- a/bin/physlr-make
+++ b/bin/physlr-make
@@ -17,9 +17,6 @@ bloom_filter_size=10000000000 #10GB
 # Molecule separation stratergy
 mol_strategy=distributed
 
-# Maximum minimizer multiplicity
-minimizer_multiplicity=100
-
 # Path to the Physlr project.
 physlr_path=$(shell dirname $$(dirname $(realpath $(MAKEFILE_LIST))))
 
@@ -177,7 +174,9 @@ help:
 	@echo "	min_component_size		minimum number of barcodes in a backbone [50]."
 	@echo "	minimum_barcode_multiplicity	minimum number of minimizers per barcode [10]."
 	@echo "	maximum_barcode_multiplicity	maximum number of minimizers per barcode [5000]."
-	@echo "	minimizer_multiplicity		Available option is x. Specify x to use the Q3 + IQR of the minimizer multiplicity distribution instead of the repetitive k-mer threshold."
+	@echo "	minimizer_multiplicity		maximum minimizer multiplicity [repetitive k-mer threshold based on ntCard]."
+	@echo "					Specify x to use the Q3 + IQR of the minimizer multiplicity distribution instead."
+	@echo "					Specify x to use the Q3 + IQR of the minimizer multiplicity distribution instead."
 	@echo "	mol_strategy			molecule separation strategy [distributed]. Available options are bc, bc+k3, distributed."
 	@echo "					bc (biconnected componenets) is the least conservative and is only suitable for datasets with low barcode multiplicity."
 	@echo "					bc+k3 (biconnected componenets + k-3 cliques) is most conservative and requires more time."
@@ -856,13 +855,17 @@ ifeq ($(minimizer_multiplicity),x)
 	$(zcat) $< | $(time) $(physlr_path)/src/physlr-filter-bxmx -o $@ -
 else
 ifeq (n,$(findstring n,$(firstword -$(MAKEFLAGS))))
+ifndef minimizer_multiplicity
 	mode=$(python) $(bin)/physlr find-ntcard-mode $*_k$k.histogram
 	minimizer_multiplicity ?= expr mode * 3
+endif
 else
+ifndef minimizer_multiplicity
 	$(eval mode := $(shell $(python) $(bin)/physlr find-ntcard-mode $*_k$k.histogram))
 	$(eval minimizer_multiplicity ?= $(shell (expr $(mode) \* 3 ) ))
-endif
 	@>&2 echo "The minimizer multiplicity is $(minimizer_multiplicity)."
+endif
+endif
 	$(zcat) $< | $(time) $(physlr_path)/src/physlr-filter-bxmx -C $(minimizer_multiplicity) -o $@ -
 endif
 

--- a/bin/physlr-make
+++ b/bin/physlr-make
@@ -176,7 +176,7 @@ help:
 	@echo "	maximum_barcode_multiplicity	maximum number of minimizers per barcode [5000]."
 	@echo "	minimizer_multiplicity		maximum minimizer multiplicity [repetitive k-mer threshold based on ntCard]."
 	@echo "					Specify x to use the Q3 + IQR of the minimizer multiplicity distribution instead."
-	@echo "					Specify x to use the Q3 + IQR of the minimizer multiplicity distribution instead."
+	@echo "					Alternatively, you can specify an integer threshold of your choosing."
 	@echo "	mol_strategy			molecule separation strategy [distributed]. Available options are bc, bc+k3, distributed."
 	@echo "					bc (biconnected componenets) is the least conservative and is only suitable for datasets with low barcode multiplicity."
 	@echo "					bc+k3 (biconnected componenets + k-3 cliques) is most conservative and requires more time."

--- a/bin/physlr-make
+++ b/bin/physlr-make
@@ -177,7 +177,7 @@ help:
 	@echo "	min_component_size		minimum number of barcodes in a backbone [50]."
 	@echo "	minimum_barcode_multiplicity	minimum number of minimizers per barcode [10]."
 	@echo "	maximum_barcode_multiplicity	maximum number of minimizers per barcode [5000]."
-	@echo "	minimizer_multiplicity		maximum minimizer multiplicity [100]. Specify x to use the Q3 + IQR of the minimizer multiplicity distribution instead."
+	@echo "	minimizer_multiplicity		Available option is x. Specify x to use the Q3 + IQR of the minimizer multiplicity distribution instead of the repetitive k-mer threshold."
 	@echo "	mol_strategy			molecule separation strategy [distributed]. Available options are bc, bc+k3, distributed."
 	@echo "					bc (biconnected componenets) is the least conservative and is only suitable for datasets with low barcode multiplicity."
 	@echo "					bc+k3 (biconnected componenets + k-3 cliques) is most conservative and requires more time."
@@ -855,6 +855,14 @@ $(ref)/$(ref).fa: $(ref).fa
 ifeq ($(minimizer_multiplicity),x)
 	$(zcat) $< | $(time) $(physlr_path)/src/physlr-filter-bxmx -o $@ -
 else
+ifeq (n,$(findstring n,$(firstword -$(MAKEFLAGS))))
+	mode=$(python) $(bin)/physlr find-ntcard-mode $*_k$k.histogram
+	minimizer_multiplicity ?= expr mode * 3
+else
+	$(eval mode := $(shell $(python) $(bin)/physlr find-ntcard-mode $*_k$k.histogram))
+	$(eval minimizer_multiplicity ?= $(shell (expr $(mode) \* 3 ) ))
+endif
+	@>&2 echo "The minimizer multiplicity is $(minimizer_multiplicity)."
 	$(zcat) $< | $(time) $(physlr_path)/src/physlr-filter-bxmx -C $(minimizer_multiplicity) -o $@ -
 endif
 

--- a/bin/physlr-make
+++ b/bin/physlr-make
@@ -96,13 +96,13 @@ endif
 .PHONY: f1chr4 f1chr2R f1 fishchr25 fish physical-map scaffolds
 all: f1chr4 f1chr2R f1 fishchr25 fish
 
-$(lr).physlr.physical-map.path: $(lr).k$k-w$w.n$(minimum_barcode_multiplicity)-$(maximum_barcode_multiplicity).c2-$(minimizer_multiplicity).physlr.overlap.m$m.mol.mol2-bcs.backbone.path
+$(lr).physlr.physical-map.path: $(lr).k$k-w$w.n$(minimum_barcode_multiplicity)-$(maximum_barcode_multiplicity).c2-x.physlr.overlap.m$m.mol.mol2-bcs.backbone.path
 	ln -sf $< $@
 
-$(lr).physlr.physical-map.$(ref).n10.paf.gz: $(lr).k$k-w$w.n$(minimum_barcode_multiplicity)-$(maximum_barcode_multiplicity).c2-$(minimizer_multiplicity).physlr.overlap.m$m.mol.mol2-bcs.backbone.map.$(ref).n10.paf.gz
+$(lr).physlr.physical-map.$(ref).n10.paf.gz: $(lr).k$k-w$w.n$(minimum_barcode_multiplicity)-$(maximum_barcode_multiplicity).c2-x.physlr.overlap.m$m.mol.mol2-bcs.backbone.map.$(ref).n10.paf.gz
 	ln -sf $< $@
 
-$(draft).physlr.fa: $(lr).k$k-w$w.n$(minimum_barcode_multiplicity)-$(maximum_barcode_multiplicity).c2-$(minimizer_multiplicity).physlr.overlap.m$m.mol.mol2-bcs.backbone.map.$(draft).n10.sort.best.bed.path.fa
+$(draft).physlr.fa: $(lr).k$k-w$w.n$(minimum_barcode_multiplicity)-$(maximum_barcode_multiplicity).c2-x.physlr.overlap.m$m.mol.mol2-bcs.backbone.map.$(draft).n10.sort.best.bed.path.fa
 	ln -sf $< $@
 
 scaffolds:
@@ -174,9 +174,6 @@ help:
 	@echo "	min_component_size		minimum number of barcodes in a backbone [50]."
 	@echo "	minimum_barcode_multiplicity	minimum number of minimizers per barcode [10]."
 	@echo "	maximum_barcode_multiplicity	maximum number of minimizers per barcode [5000]."
-	@echo "	minimizer_multiplicity		maximum minimizer multiplicity [repetitive k-mer threshold based on ntCard]."
-	@echo "					Specify x to use the Q3 + IQR of the minimizer multiplicity distribution."
-	@echo "					Alternatively, you can specify an integer threshold of your choosing."
 	@echo "	mol_strategy			molecule separation strategy [distributed]. Available options are bc, bc+k3, distributed."
 	@echo "					bc (biconnected componenets) is the least conservative and is only suitable for datasets with low barcode multiplicity."
 	@echo "					bc+k3 (biconnected componenets + k-3 cliques) is most conservative and requires more time."
@@ -202,46 +199,46 @@ version:
 f1chr4: \
 	f1chr4.k32-w32.n100-1000.physlr.mxperbx.tsv.pdf \
 	f1chr4.k32-w32.n100-1000.physlr.depth.tsv.pdf \
-	f1chr4.k32-w32.n100-1000.c2-$(minimizer_multiplicity).physlr.overlap.n$n.mol.backbone.path.$(ref).molecule.bed.pdf \
-	f1chr4.k32-w32.n100-1000.c2-$(minimizer_multiplicity).physlr.overlap.n$n.mol.backbone.map.$(ref).n10.paf.gz.pdf \
-	f1chr4.k32-w32.n100-1000.c2-$(minimizer_multiplicity).physlr.overlap.n$n.mol.backbone.map.$(draft).n10.sort.best.bed.pdf \
-	f1chr4.k32-w32.n100-1000.c2-$(minimizer_multiplicity).physlr.overlap.n$n.mol.backbone.map.$(draft).n10.sort.best.bed.path.$(ref).minidot.pdf \
-	f1chr4.k32-w32.n100-1000.c2-$(minimizer_multiplicity).physlr.overlap.n$n.mol.backbone.label.gv.pdf \
-	f1chr4.k32-w32.n100-1000.c2-$(minimizer_multiplicity).physlr.overlap.n$n.mol.backbone.map.$(ref).n10.ann.gv.squish.pdf
+	f1chr4.k32-w32.n100-1000.c2-x.physlr.overlap.n$n.mol.backbone.path.$(ref).molecule.bed.pdf \
+	f1chr4.k32-w32.n100-1000.c2-x.physlr.overlap.n$n.mol.backbone.map.$(ref).n10.paf.gz.pdf \
+	f1chr4.k32-w32.n100-1000.c2-x.physlr.overlap.n$n.mol.backbone.map.$(draft).n10.sort.best.bed.pdf \
+	f1chr4.k32-w32.n100-1000.c2-x.physlr.overlap.n$n.mol.backbone.map.$(draft).n10.sort.best.bed.path.$(ref).minidot.pdf \
+	f1chr4.k32-w32.n100-1000.c2-x.physlr.overlap.n$n.mol.backbone.label.gv.pdf \
+	f1chr4.k32-w32.n100-1000.c2-x.physlr.overlap.n$n.mol.backbone.map.$(ref).n10.ann.gv.squish.pdf
 
 # Assemble a physical map of fly chromosome 2R.
 # ref=fly lr=f1chr2R draft=f1.supernova.scaftigs n=50 minimizer_multiplicity=x
 f1chr2R: \
 	f1chr2R.k32-w32.n100-1000.physlr.mxperbx.tsv.pdf \
 	f1chr2R.k32-w32.n100-1000.physlr.depth.tsv.pdf \
-	f1chr2R.k32-w32.n100-1000.c2-$(minimizer_multiplicity).physlr.overlap.n$n.mol.backbone.path.$(ref).molecule.bed.pdf \
-	f1chr2R.k32-w32.n100-1000.c2-$(minimizer_multiplicity).physlr.overlap.n$n.mol.backbone.map.$(ref).n10.paf.gz.pdf \
-	f1chr2R.k32-w32.n100-1000.c2-$(minimizer_multiplicity).physlr.overlap.n$n.mol.backbone.map.$(draft).n10.sort.best.bed.pdf \
-	f1chr2R.k32-w32.n100-1000.c2-$(minimizer_multiplicity).physlr.overlap.n$n.mol.backbone.map.$(draft).n10.sort.best.bed.path.$(ref).minidot.pdf \
-	f1chr2R.k32-w32.n100-1000.c2-$(minimizer_multiplicity).physlr.overlap.n$n.mol.backbone.label.gv.pdf \
-	f1chr2R.k32-w32.n100-1000.c2-$(minimizer_multiplicity).physlr.overlap.n$n.mol.backbone.map.$(ref).n10.ann.gv.squish.pdf
+	f1chr2R.k32-w32.n100-1000.c2-x.physlr.overlap.n$n.mol.backbone.path.$(ref).molecule.bed.pdf \
+	f1chr2R.k32-w32.n100-1000.c2-x.physlr.overlap.n$n.mol.backbone.map.$(ref).n10.paf.gz.pdf \
+	f1chr2R.k32-w32.n100-1000.c2-x.physlr.overlap.n$n.mol.backbone.map.$(draft).n10.sort.best.bed.pdf \
+	f1chr2R.k32-w32.n100-1000.c2-x.physlr.overlap.n$n.mol.backbone.map.$(draft).n10.sort.best.bed.path.$(ref).minidot.pdf \
+	f1chr2R.k32-w32.n100-1000.c2-x.physlr.overlap.n$n.mol.backbone.label.gv.pdf \
+	f1chr2R.k32-w32.n100-1000.c2-x.physlr.overlap.n$n.mol.backbone.map.$(ref).n10.ann.gv.squish.pdf
 
 # Assemble a physical map of the fly genome.
 # ref=fly lr=f1 draft=f1.supernova.scaftigs n=25 minimizer_multiplicity=x
 f1: \
 	f1.k32-w32.n100-1000.physlr.mxperbx.tsv.pdf \
 	f1.k32-w32.n100-1000.physlr.depth.tsv.pdf \
-	f1.k32-w32.n100-1000.c2-$(minimizer_multiplicity).physlr.overlap.n$n.mol.backbone.path.$(ref).molecule.bed.pdf \
-	f1.k32-w32.n100-1000.c2-$(minimizer_multiplicity).physlr.overlap.n$n.mol.backbone.map.$(ref).n10.paf.gz.pdf \
-	f1.k32-w32.n100-1000.c2-$(minimizer_multiplicity).physlr.overlap.n$n.mol.backbone.map.$(draft).n10.sort.best.bed.pdf \
-	f1.k32-w32.n100-1000.c2-$(minimizer_multiplicity).physlr.overlap.n$n.mol.backbone.map.$(draft).n10.sort.best.bed.path.$(ref).minidot.pdf \
-	f1.k32-w32.n100-1000.c2-$(minimizer_multiplicity).physlr.overlap.n$n.mol.backbone.map.$(draft).n10.sort.best.bed.path.quast.tsv \
-	f1.k32-w32.n100-1000.c2-$(minimizer_multiplicity).physlr.overlap.n$n.mol.backbone.map-mkt.$(draft).n10.sort.best.bed.path.quast.tsv \
-	f1.k32-w32.n100-1000.c2-$(minimizer_multiplicity).physlr.overlap.n$n.mol.backbone.label.gv.pdf \
-	f1.k32-w32.n100-1000.c2-$(minimizer_multiplicity).physlr.overlap.n$n.mol.backbone.map.$(ref).n10.ann.gv.squish.pdf
+	f1.k32-w32.n100-1000.c2-x.physlr.overlap.n$n.mol.backbone.path.$(ref).molecule.bed.pdf \
+	f1.k32-w32.n100-1000.c2-x.physlr.overlap.n$n.mol.backbone.map.$(ref).n10.paf.gz.pdf \
+	f1.k32-w32.n100-1000.c2-x.physlr.overlap.n$n.mol.backbone.map.$(draft).n10.sort.best.bed.pdf \
+	f1.k32-w32.n100-1000.c2-x.physlr.overlap.n$n.mol.backbone.map.$(draft).n10.sort.best.bed.path.$(ref).minidot.pdf \
+	f1.k32-w32.n100-1000.c2-x.physlr.overlap.n$n.mol.backbone.map.$(draft).n10.sort.best.bed.path.quast.tsv \
+	f1.k32-w32.n100-1000.c2-x.physlr.overlap.n$n.mol.backbone.map-mkt.$(draft).n10.sort.best.bed.path.quast.tsv \
+	f1.k32-w32.n100-1000.c2-x.physlr.overlap.n$n.mol.backbone.label.gv.pdf \
+	f1.k32-w32.n100-1000.c2-x.physlr.overlap.n$n.mol.backbone.map.$(ref).n10.ann.gv.squish.pdf
 
 # Scaffold the ABySS assembly of the fly genome.
 # ref=fly lr=f1 draft=f1.abyss n=25 minimizer_multiplicity=x
 f1-abyss: \
-	f1.k32-w32.n100-1000.c2-$(minimizer_multiplicity).physlr.overlap.n$n.mol.backbone.map.$(draft).n10.sort.best.bed.pdf \
-	f1.k32-w32.n100-1000.c2-$(minimizer_multiplicity).physlr.overlap.n$n.mol.backbone.map.$(draft).n10.sort.best.bed.path.$(ref).minidot.pdf \
-	f1.k32-w32.n100-1000.c2-$(minimizer_multiplicity).physlr.overlap.n$n.mol.backbone.map.$(draft).n10.sort.best.bed.path.quast.tsv \
-	f1.k32-w32.n100-1000.c2-$(minimizer_multiplicity).physlr.overlap.n$n.mol.backbone.map-mkt.$(draft).n10.sort.best.bed.path.quast.tsv
+	f1.k32-w32.n100-1000.c2-x.physlr.overlap.n$n.mol.backbone.map.$(draft).n10.sort.best.bed.pdf \
+	f1.k32-w32.n100-1000.c2-x.physlr.overlap.n$n.mol.backbone.map.$(draft).n10.sort.best.bed.path.$(ref).minidot.pdf \
+	f1.k32-w32.n100-1000.c2-x.physlr.overlap.n$n.mol.backbone.map.$(draft).n10.sort.best.bed.path.quast.tsv \
+	f1.k32-w32.n100-1000.c2-x.physlr.overlap.n$n.mol.backbone.map-mkt.$(draft).n10.sort.best.bed.path.quast.tsv
 
 # Aggregate QUAST metrics.
 f1.quast.tsv: \
@@ -249,10 +246,10 @@ f1.quast.tsv: \
 		f1.abyss.scaftigs.quast.tsv \
 		f1.supernova.quast.tsv \
 		f1.supernova.scaftigs.quast.tsv \
-		f1.k32-w32.n100-1000.c2-$(minimizer_multiplicity).physlr.overlap.n25.mol.backbone.map.f1.abyss.n10.sort.best.bed.path.quast.tsv \
-		f1.k32-w32.n100-1000.c2-$(minimizer_multiplicity).physlr.overlap.n25.mol.backbone.map-mkt.f1.abyss.n10.sort.best.bed.path.quast.tsv \
-		f1.k32-w32.n100-1000.c2-$(minimizer_multiplicity).physlr.overlap.n25.mol.backbone.map.f1.supernova.scaftigs.n10.sort.best.bed.path.quast.tsv \
-		f1.k32-w32.n100-1000.c2-$(minimizer_multiplicity).physlr.overlap.n25.mol.backbone.map-mkt.f1.supernova.scaftigs.n10.sort.best.bed.path.quast.tsv
+		f1.k32-w32.n100-1000.c2-x.physlr.overlap.n25.mol.backbone.map.f1.abyss.n10.sort.best.bed.path.quast.tsv \
+		f1.k32-w32.n100-1000.c2-x.physlr.overlap.n25.mol.backbone.map-mkt.f1.abyss.n10.sort.best.bed.path.quast.tsv \
+		f1.k32-w32.n100-1000.c2-x.physlr.overlap.n25.mol.backbone.map.f1.supernova.scaftigs.n10.sort.best.bed.path.quast.tsv \
+		f1.k32-w32.n100-1000.c2-x.physlr.overlap.n25.mol.backbone.map-mkt.f1.supernova.scaftigs.n10.sort.best.bed.path.quast.tsv
 	mlr --tsvlite cut -x -f NG75,NGA75,LG75,LGA75 $^ >$@
 
 # Download the fly genome from Ensembl.
@@ -342,32 +339,32 @@ f1chr2R-bx%.fq.gz: fly/fly.f1.chr2R.sortbxn.dropse.bx%.fq.gz
 # Assemble a physical map of fish.
 # ref=z11 lr=fish draft=fish.supernova n=40 min_component_size=200 minimizer_multiplicity=x
 fish: \
-	fish.k32-w32.n100-2000.c2-$(minimizer_multiplicity).physlr.overlap.n$n.k3.mol.backbone.path.z11.molecule.bed.pdf \
-	fish.k32-w32.n100-2000.c2-$(minimizer_multiplicity).physlr.overlap.n$n.k3.mol.backbone.map.z11.n10.paf.gz.pdf \
-	fish.k32-w32.n100-2000.c2-$(minimizer_multiplicity).physlr.overlap.n$n.k3.mol.backbone.map.fish.supernova.n10.sort.best.bed.pdf \
-	fish.k32-w32.n100-2000.c2-$(minimizer_multiplicity).physlr.overlap.n$n.k3.mol.backbone.map.fish.supernova.n10.sort.best.bed.path.z11.minidot.pdf \
-	fish.k32-w32.n100-2000.c2-$(minimizer_multiplicity).physlr.overlap.n$n.k3.mol.backbone.map.fish.supernova.n10.sort.best.bed.path.quast.tsv \
-	fish.k32-w32.n100-2000.c2-$(minimizer_multiplicity).physlr.overlap.n$n.k3.mol.backbone.map-mkt.fish.supernova.n10.sort.best.bed.path.quast.tsv \
-	fish.k32-w32.n100-2000.c2-$(minimizer_multiplicity).physlr.overlap.n$n.k3.mol.backbone.map.z11.n10.ann.gv.squish.pdf
+	fish.k32-w32.n100-2000.c2-x.physlr.overlap.n$n.k3.mol.backbone.path.z11.molecule.bed.pdf \
+	fish.k32-w32.n100-2000.c2-x.physlr.overlap.n$n.k3.mol.backbone.map.z11.n10.paf.gz.pdf \
+	fish.k32-w32.n100-2000.c2-x.physlr.overlap.n$n.k3.mol.backbone.map.fish.supernova.n10.sort.best.bed.pdf \
+	fish.k32-w32.n100-2000.c2-x.physlr.overlap.n$n.k3.mol.backbone.map.fish.supernova.n10.sort.best.bed.path.z11.minidot.pdf \
+	fish.k32-w32.n100-2000.c2-x.physlr.overlap.n$n.k3.mol.backbone.map.fish.supernova.n10.sort.best.bed.path.quast.tsv \
+	fish.k32-w32.n100-2000.c2-x.physlr.overlap.n$n.k3.mol.backbone.map-mkt.fish.supernova.n10.sort.best.bed.path.quast.tsv \
+	fish.k32-w32.n100-2000.c2-x.physlr.overlap.n$n.k3.mol.backbone.map.z11.n10.ann.gv.squish.pdf
 
 # Aggregate QUAST metrics.
 fish.quast.tsv: \
 		fish.supernova.scaftigs.quast.tsv \
 		fish.supernova.quast.tsv \
-		fish.k32-w32.n100-2000.c2-$(minimizer_multiplicity).physlr.overlap.n40.k3.mol.backbone.map.fish.supernova.n10.sort.best.bed.path.quast.tsv \
-		fish.k32-w32.n100-2000.c2-$(minimizer_multiplicity).physlr.overlap.n40.k3.mol.backbone.map-mkt.fish.supernova.n10.sort.best.bed.path.quast.tsv
+		fish.k32-w32.n100-2000.c2-x.physlr.overlap.n40.k3.mol.backbone.map.fish.supernova.n10.sort.best.bed.path.quast.tsv \
+		fish.k32-w32.n100-2000.c2-x.physlr.overlap.n40.k3.mol.backbone.map-mkt.fish.supernova.n10.sort.best.bed.path.quast.tsv
 	mlr --tsvlite cut -x -f NG75,NGA75,LG75,LGA75 $^ >$@
 
 # Assemble a physical map of fish chromosome 25.
 # ref=z11chr25 lr=fishchr25 draft=fish.supernova.chr25 n=50 minimizer_multiplicity=x
 fishchr25: \
-	fishchr25.k32-w32.n100-2000.c2-$(minimizer_multiplicity).physlr.overlap.n$n.mol.backbone.label.gv.pdf \
-	fishchr25.k32-w32.n100-2000.c2-$(minimizer_multiplicity).physlr.overlap.n$n.mol.backbone.path.z11chr25.molecule.bed.pdf \
-	fishchr25.k32-w32.n100-2000.c2-$(minimizer_multiplicity).physlr.overlap.n$n.mol.backbone.map.z11chr25.n10.paf.gz.pdf \
-	fishchr25.k32-w32.n100-2000.c2-$(minimizer_multiplicity).physlr.overlap.n$n.mol.backbone.map.fish.supernova.chr25.n10.sort.best.bed.pdf \
-	fishchr25.k32-w32.n100-2000.c2-$(minimizer_multiplicity).physlr.overlap.n$n.mol.backbone.map.fish.supernova.chr25.n10.sort.best.bed.path.z11chr25.minidot.pdf \
-	fishchr25.k32-w32.n100-2000.c2-$(minimizer_multiplicity).physlr.overlap.n$n.mol.backbone.map.fish.supernova.chr25.n10.sort.best.bed.path.quast.tsv \
-	fishchr25.k32-w32.n100-2000.c2-$(minimizer_multiplicity).physlr.overlap.n$n.mol.backbone.map.z11chr25.n10.ann.gv.squish.pdf
+	fishchr25.k32-w32.n100-2000.c2-x.physlr.overlap.n$n.mol.backbone.label.gv.pdf \
+	fishchr25.k32-w32.n100-2000.c2-x.physlr.overlap.n$n.mol.backbone.path.z11chr25.molecule.bed.pdf \
+	fishchr25.k32-w32.n100-2000.c2-x.physlr.overlap.n$n.mol.backbone.map.z11chr25.n10.paf.gz.pdf \
+	fishchr25.k32-w32.n100-2000.c2-x.physlr.overlap.n$n.mol.backbone.map.fish.supernova.chr25.n10.sort.best.bed.pdf \
+	fishchr25.k32-w32.n100-2000.c2-x.physlr.overlap.n$n.mol.backbone.map.fish.supernova.chr25.n10.sort.best.bed.path.z11chr25.minidot.pdf \
+	fishchr25.k32-w32.n100-2000.c2-x.physlr.overlap.n$n.mol.backbone.map.fish.supernova.chr25.n10.sort.best.bed.path.quast.tsv \
+	fishchr25.k32-w32.n100-2000.c2-x.physlr.overlap.n$n.mol.backbone.map.z11chr25.n10.ann.gv.squish.pdf
 
 # Download the zebrafish genome from NCBI.
 fish/z11.ncbi.fa:
@@ -426,19 +423,19 @@ fishchr25.fq.gz: fish/z11.fish.chr25.sortbxn.dropse.fq.gz
 maize: \
 	maize.k32-w32.n100-5000.physlr.mxperbx.tsv.pdf \
 	maize.k32-w32.n100-5000.physlr.depth.tsv.pdf \
-	maize.k32-w32.n100-5000.c2-$(minimizer_multiplicity).physlr.overlap.n$n.k3.mol.backbone.map.b73.n10.paf.gz.pdf \
-	maize.k32-w32.n100-5000.c2-$(minimizer_multiplicity).physlr.overlap.n$n.k3.mol.backbone.map.maize.supernova.n10.sort.best.bed.pdf \
-	maize.k32-w32.n100-5000.c2-$(minimizer_multiplicity).physlr.overlap.n$n.k3.mol.backbone.map.maize.supernova.n10.sort.best.bed.path.b73.minidot.pdf \
-	maize.k32-w32.n100-5000.c2-$(minimizer_multiplicity).physlr.overlap.n$n.k3.mol.backbone.map.maize.supernova.n10.sort.best.bed.path.quast.tsv \
-	maize.k32-w32.n100-5000.c2-$(minimizer_multiplicity).physlr.overlap.n$n.k3.mol.backbone.map-mkt.maize.supernova.n10.sort.best.bed.path.quast.tsv \
-	maize.k32-w32.n100-5000.c2-$(minimizer_multiplicity).physlr.overlap.n$n.k3.mol.backbone.map.b73.n10.ann.gv.squish.pdf
+	maize.k32-w32.n100-5000.c2-x.physlr.overlap.n$n.k3.mol.backbone.map.b73.n10.paf.gz.pdf \
+	maize.k32-w32.n100-5000.c2-x.physlr.overlap.n$n.k3.mol.backbone.map.maize.supernova.n10.sort.best.bed.pdf \
+	maize.k32-w32.n100-5000.c2-x.physlr.overlap.n$n.k3.mol.backbone.map.maize.supernova.n10.sort.best.bed.path.b73.minidot.pdf \
+	maize.k32-w32.n100-5000.c2-x.physlr.overlap.n$n.k3.mol.backbone.map.maize.supernova.n10.sort.best.bed.path.quast.tsv \
+	maize.k32-w32.n100-5000.c2-x.physlr.overlap.n$n.k3.mol.backbone.map-mkt.maize.supernova.n10.sort.best.bed.path.quast.tsv \
+	maize.k32-w32.n100-5000.c2-x.physlr.overlap.n$n.k3.mol.backbone.map.b73.n10.ann.gv.squish.pdf
 
 # Aggregate QUAST metrics.
 maize.quast.tsv: \
 		maize.supernova.scaftigs.quast.tsv \
 		maize.supernova.quast.tsv \
-		maize.k32-w32.n200-10000.c2-$(minimizer_multiplicity).physlr.overlap.n50.k3.mol.backbone.map.maize.supernova.n10.sort.best.bed.path.quast.tsv \
-		maize.k32-w32.n200-10000.c2-$(minimizer_multiplicity).physlr.overlap.n50.k3.mol.backbone.map-mkt.maize.supernova.n10.sort.best.bed.path.quast.tsv
+		maize.k32-w32.n200-10000.c2-x.physlr.overlap.n50.k3.mol.backbone.map.maize.supernova.n10.sort.best.bed.path.quast.tsv \
+		maize.k32-w32.n200-10000.c2-x.physlr.overlap.n50.k3.mol.backbone.map-mkt.maize.supernova.n10.sort.best.bed.path.quast.tsv
 	mlr --tsvlite cut -x -f NG75,NGA75,LG75,LGA75 $^ >$@
 
 # Download the maize genome from NCBI.
@@ -480,20 +477,20 @@ maize.fq.gz: maize/maize.bx.trimadap.fq.gz
 hg004: \
 	hg004.k40-w32.n100-5000.physlr.mxperbx.tsv.pdf \
 	hg004.k40-w32.n100-5000.physlr.depth.tsv.pdf \
-	hg004.k40-w32.n100-5000.c2-$(minimizer_multiplicity).physlr.overlap.n62.k3.mol.backbone.map.grch38.n10.paf.gz.pdf \
-	hg004.k40-w32.n100-5000.c2-$(minimizer_multiplicity).physlr.overlap.n62.k3.mol.backbone.map.hg004.supernova.scaftigs.n10.sort.best.bed.path.quast.tsv \
-	hg004.k40-w32.n100-5000.c2-$(minimizer_multiplicity).physlr.overlap.n62.k3.mol.backbone.map.grch38.n10.ann.gv.squish.pdf \
-	hg004.k40-w32.n100-5000.c2-$(minimizer_multiplicity).physlr.overlap.n62.k3.mol.backbone.map-mkt.hg004.supernova.scaftigs.n10.sort.best.bed.pdf \
-	hg004.k40-w32.n100-5000.c2-$(minimizer_multiplicity).physlr.overlap.n62.k3.mol.backbone.map-mkt.hg004.supernova.scaftigs.n10.sort.best.bed.path.grch38.minidot.pdf \
-	hg004.k40-w32.n100-5000.c2-$(minimizer_multiplicity).physlr.overlap.n62.k3.mol.backbone.map-mkt.hg004.supernova.scaftigs.n10.sort.best.bed.path.quast.tsv
+	hg004.k40-w32.n100-5000.c2-x.physlr.overlap.n62.k3.mol.backbone.map.grch38.n10.paf.gz.pdf \
+	hg004.k40-w32.n100-5000.c2-x.physlr.overlap.n62.k3.mol.backbone.map.hg004.supernova.scaftigs.n10.sort.best.bed.path.quast.tsv \
+	hg004.k40-w32.n100-5000.c2-x.physlr.overlap.n62.k3.mol.backbone.map.grch38.n10.ann.gv.squish.pdf \
+	hg004.k40-w32.n100-5000.c2-x.physlr.overlap.n62.k3.mol.backbone.map-mkt.hg004.supernova.scaftigs.n10.sort.best.bed.pdf \
+	hg004.k40-w32.n100-5000.c2-x.physlr.overlap.n62.k3.mol.backbone.map-mkt.hg004.supernova.scaftigs.n10.sort.best.bed.path.grch38.minidot.pdf \
+	hg004.k40-w32.n100-5000.c2-x.physlr.overlap.n62.k3.mol.backbone.map-mkt.hg004.supernova.scaftigs.n10.sort.best.bed.path.quast.tsv
 
 # Scaffold the ABySS assembly with the physical map of hg004.
 # ref=grch38 lr=hg004 draft=hg004.abyss k=40 w=32 n=62 min_component_size=200 minimizer_multiplicity=x
 hg004-abyss: \
-	hg004.k40-w32.n100-5000.c2-$(minimizer_multiplicity).physlr.overlap.n62.k3.mol.backbone.map.hg004.abyss.n10.sort.best.bed.pdf \
-	hg004.k40-w32.n100-5000.c2-$(minimizer_multiplicity).physlr.overlap.n62.k3.mol.backbone.map.hg004.abyss.n10.sort.best.bed.path.grch38.minidot.pdf \
-	hg004.k40-w32.n100-5000.c2-$(minimizer_multiplicity).physlr.overlap.n62.k3.mol.backbone.map.hg004.abyss.n10.sort.best.bed.path.quast.tsv \
-	hg004.k40-w32.n100-5000.c2-$(minimizer_multiplicity).physlr.overlap.n62.k3.mol.backbone.map-mkt.hg004.abyss.n10.sort.best.bed.path.quast.tsv
+	hg004.k40-w32.n100-5000.c2-x.physlr.overlap.n62.k3.mol.backbone.map.hg004.abyss.n10.sort.best.bed.pdf \
+	hg004.k40-w32.n100-5000.c2-x.physlr.overlap.n62.k3.mol.backbone.map.hg004.abyss.n10.sort.best.bed.path.grch38.minidot.pdf \
+	hg004.k40-w32.n100-5000.c2-x.physlr.overlap.n62.k3.mol.backbone.map.hg004.abyss.n10.sort.best.bed.path.quast.tsv \
+	hg004.k40-w32.n100-5000.c2-x.physlr.overlap.n62.k3.mol.backbone.map-mkt.hg004.abyss.n10.sort.best.bed.path.quast.tsv
 
 # Download the human genome from NCBI.
 grch38/grch38.all.fa:
@@ -525,11 +522,11 @@ hg004.quast.tsv: \
 		hg004.abyss.quast.tsv \
 		hg004.supernova.quast.tsv \
 		hg004.supernova.scaftigs.quast.tsv \
-		hg004.k40-w32.n100-5000.c2-$(minimizer_multiplicity).physlr.overlap.n62.k3.mol.backbone.map.hg004.abyss.n10.sort.best.bed.path.quast.tsv \
-		hg004.k40-w32.n100-5000.c2-$(minimizer_multiplicity).physlr.overlap.n62.k3.mol.backbone.map-mkt.hg004.abyss.n10.sort.best.bed.path.quast.tsv \
-		hg004.k40-w32.n100-5000.c2-$(minimizer_multiplicity).physlr.overlap.n62.k3.mol.backbone.map.hg004.supernova.scaftigs.n10.sort.best.bed.path.quast.tsv \
-		hg004.k40-w32.n100-5000.c2-$(minimizer_multiplicity).physlr.overlap.n62.k3.mol.backbone.map-mkt.hg004.supernova.scaftigs.n10.sort.best.bed.path.quast.tsv \
-		hg004.k40-w32.n100-5000.c2-$(minimizer_multiplicity).physlr.overlap.n62.k3.mol.backbone.map.hg004.supernova.n10.sort.best.bed.path.quast.tsv
+		hg004.k40-w32.n100-5000.c2-x.physlr.overlap.n62.k3.mol.backbone.map.hg004.abyss.n10.sort.best.bed.path.quast.tsv \
+		hg004.k40-w32.n100-5000.c2-x.physlr.overlap.n62.k3.mol.backbone.map-mkt.hg004.abyss.n10.sort.best.bed.path.quast.tsv \
+		hg004.k40-w32.n100-5000.c2-x.physlr.overlap.n62.k3.mol.backbone.map.hg004.supernova.scaftigs.n10.sort.best.bed.path.quast.tsv \
+		hg004.k40-w32.n100-5000.c2-x.physlr.overlap.n62.k3.mol.backbone.map-mkt.hg004.supernova.scaftigs.n10.sort.best.bed.path.quast.tsv \
+		hg004.k40-w32.n100-5000.c2-x.physlr.overlap.n62.k3.mol.backbone.map.hg004.supernova.n10.sort.best.bed.path.quast.tsv
 	mlr --tsvlite cut -x -f NG75,NGA75,LG75,LGA75 $^ >$@
 
 ################################################################################
@@ -542,9 +539,9 @@ hg004.quast.tsv: \
 redcedar: \
 	redcedar.k32-w32.n100-5000.physlr.mxperbx.tsv.pdf \
 	redcedar.k32-w32.n100-5000.physlr.depth.tsv.pdf \
-	redcedar.k32-w32.n100-5000.c2-$(minimizer_multiplicity).physlr.overlap.n$n.mol.backbone.path \
-	redcedar.k32-w32.n100-5000.c2-$(minimizer_multiplicity).physlr.overlap.n$n.mol.backbone.map.redcedar.abyss.n10.sort.best.bed.path.fa \
-	redcedar.k32-w32.n100-5000.c2-$(minimizer_multiplicity).physlr.overlap.n$n.mol.backbone.map.redcedar.abyss.n10.sort.best.bed.pdf
+	redcedar.k32-w32.n100-5000.c2-x.physlr.overlap.n$n.mol.backbone.path \
+	redcedar.k32-w32.n100-5000.c2-x.physlr.overlap.n$n.mol.backbone.map.redcedar.abyss.n10.sort.best.bed.path.fa \
+	redcedar.k32-w32.n100-5000.c2-x.physlr.overlap.n$n.mol.backbone.map.redcedar.abyss.n10.sort.best.bed.pdf
 
 # Symlink the linked reads.
 redcedar.fq.gz: redcedar.lrbasic.trimadap.fq.gz
@@ -558,9 +555,9 @@ redcedar.fq.gz: redcedar.lrbasic.trimadap.fq.gz
 ws77111: \
 	ws77111.k32-w32.n100-5000.physlr.mxperbx.tsv.pdf \
 	ws77111.k32-w32.n100-5000.physlr.depth.tsv.pdf \
-	ws77111.k32-w32.n100-5000.c2-$(minimizer_multiplicity).physlr.overlap.n$n.mol.backbone.path \
-	ws77111.k32-w32.n100-5000.c2-$(minimizer_multiplicity).physlr.overlap.n$n.mol.backbone.map.ws77111.abyss.n10.sort.best.bed.path.fa \
-	ws77111.k32-w32.n100-5000.c2-$(minimizer_multiplicity).physlr.overlap.n$n.mol.backbone.map.ws77111.abyss.n10.sort.best.bed.pdf
+	ws77111.k32-w32.n100-5000.c2-x.physlr.overlap.n$n.mol.backbone.path \
+	ws77111.k32-w32.n100-5000.c2-x.physlr.overlap.n$n.mol.backbone.map.ws77111.abyss.n10.sort.best.bed.path.fa \
+	ws77111.k32-w32.n100-5000.c2-x.physlr.overlap.n$n.mol.backbone.map.ws77111.abyss.n10.sort.best.bed.pdf
 
 # Trim adapter sequences using trimadap.
 ws77111.lrbasic.trimadap.fq.gz: path=/projects/spruceup/pglauca/WS77111/data/reads/DNA/fastq/chromium
@@ -767,7 +764,7 @@ ifeq (n,$(findstring n,$(firstword -$(MAKEFLAGS))))
 	mode=$(python) $(bin)/physlr find-ntcard-mode $*_k$k.histogram
 	repeat_threshold ?= expr mode * 3
 else
-	$(eval mode := $(shell $(python) $(bin)/physlr find-ntcard-mode $*_k$k.histogram))
+	$(eval mode := $(shell $(python) $(bin)/physlr find-ntcard-mode $(lr)_k$k.histogram))
 	$(eval repeat_threshold ?= $(shell (expr $(mode) \* 3 ) ))
 endif
 	@>&2 echo "The mode k-mer coverage is $(mode)."
@@ -849,19 +846,23 @@ $(ref)/$(ref).fa: $(ref).fa
 %.physlr.depth.tsv: %.physlr.tsv.gz
 	$(zcat) $< | $(time) $(python) $(bin)/physlr count-minimizers -V$V - >$@
 
+
+#minimizer_multiplicity		maximum minimizer multiplicity [repetitive k-mer threshold based on ntCard]."
+#					Specify x to use the Q3 + IQR of the minimizer multiplicity distribution."
+#					Alternatively, you can specify an integer threshold of your choosing."
 # Filter minimizers by their frequency.
-%.c2-$(minimizer_multiplicity).physlr.tsv: %.physlr.tsv.gz
+%.c2-x.physlr.tsv: %.physlr.tsv.gz
 ifeq ($(minimizer_multiplicity),x)
 	$(zcat) $< | $(time) $(physlr_path)/src/physlr-filter-bxmx -o $@ -
 else
 ifeq (n,$(findstring n,$(firstword -$(MAKEFLAGS))))
 ifndef minimizer_multiplicity
-	mode=$(python) $(bin)/physlr find-ntcard-mode $*_k$k.histogram
+	mode=$(python) $(bin)/physlr find-ntcard-mode $(lr)_k$k.histogram
 	minimizer_multiplicity ?= expr mode * 3
 endif
 else
 ifndef minimizer_multiplicity
-	$(eval mode := $(shell $(python) $(bin)/physlr find-ntcard-mode $*_k$k.histogram))
+	$(eval mode := $(shell $(python) $(bin)/physlr find-ntcard-mode $(lr)_k$k.histogram))
 	$(eval minimizer_multiplicity ?= $(shell (expr $(mode) \* 3 ) ))
 	@>&2 echo "The minimizer multiplicity is $(minimizer_multiplicity)."
 endif
@@ -948,7 +949,7 @@ min_path_size=200
 	$(time) $(python) $(bin)/physlr map -V$V -n10 $^ $(lr).n100-2000.physlr.tsv >$@
 
 # Map the draft assembly to the backbone graph and output BED.
-%.backbone.map.$(draft).n10.bed: %.backbone.path $(lr).k$k-w$w.n$(minimum_barcode_multiplicity)-$(maximum_barcode_multiplicity).c2-$(minimizer_multiplicity).physlr.tsv $(draft).k$k-w$w.physlr.tsv
+%.backbone.map.$(draft).n10.bed: %.backbone.path $(lr).k$k-w$w.n$(minimum_barcode_multiplicity)-$(maximum_barcode_multiplicity).c2-x.physlr.tsv $(draft).k$k-w$w.physlr.tsv
 	$(time) $(python) $(bin)/physlr map -V$V -n10 $^ >$@
 
 # Map the draft assembly to the backbone graph and output BED.
@@ -988,7 +989,7 @@ min_path_size=200
 	$(time) $(python) $(bin)/physlr map-mkt -V$V -n10 $^ >$@
 
 # Map the reference to the backbone graph and output PAF.
-%.map.$(ref).n10.paf.gz: %.path $(lr).k$k-w$w.n$(minimum_barcode_multiplicity)-$(maximum_barcode_multiplicity).c2-$(minimizer_multiplicity).physlr.tsv $(name)/$(ref).k$k-w$w.physlr.tsv
+%.map.$(ref).n10.paf.gz: %.path $(lr).k$k-w$w.n$(minimum_barcode_multiplicity)-$(maximum_barcode_multiplicity).c2-x.physlr.tsv $(name)/$(ref).k$k-w$w.physlr.tsv
 	$(time) $(python) $(bin)/physlr map-paf -V$V -n10 $^ | $(gzip) >$@
 
 # Lift over query coordinates of a PAF file from minimzer index to nucleotide coordinate.
@@ -1157,7 +1158,7 @@ g=$(shell awk '{x += $$2} END{print x}' $(name)/$(ref).fa.fai)
 %.quast.tsv: \
 		%.supernova.scaftigs.quast.tsv \
 		%.supernova.quast.tsv \
-		%.n100-2000.c2-$(minimizer_multiplicity).physlr.overlap.m$m.mol.backbone.map.$(name).supernova.scaftigs.n10.sort.best.bed.path.quast.tsv
+		%.n100-2000.c2-x.physlr.overlap.m$m.mol.backbone.map.$(name).supernova.scaftigs.n10.sort.best.bed.path.quast.tsv
 	mlr --tsvlite cut -x -f NG75,NGA75,LG75,LGA75 $^ >$@
 
 ################################################################################

--- a/bin/physlr-make
+++ b/bin/physlr-make
@@ -175,7 +175,7 @@ help:
 	@echo "	minimum_barcode_multiplicity	minimum number of minimizers per barcode [10]."
 	@echo "	maximum_barcode_multiplicity	maximum number of minimizers per barcode [5000]."
 	@echo "	minimizer_multiplicity		maximum minimizer multiplicity [repetitive k-mer threshold based on ntCard]."
-	@echo "					Specify x to use the Q3 + IQR of the minimizer multiplicity distribution instead."
+	@echo "					Specify x to use the Q3 + IQR of the minimizer multiplicity distribution."
 	@echo "					Alternatively, you can specify an integer threshold of your choosing."
 	@echo "	mol_strategy			molecule separation strategy [distributed]. Available options are bc, bc+k3, distributed."
 	@echo "					bc (biconnected componenets) is the least conservative and is only suitable for datasets with low barcode multiplicity."


### PR DESCRIPTION
As discussed in the abyss 10 meeting, we should use a more empirical value for minimizer multiplicity than the arbitrary 100 that I set. As k-mer multiplicity is related to minimizer multiplcity, we are going to use that.