### PR TITLE
Orient Bug Fix

### DIFF
--- a/physlr/physlr.py
+++ b/physlr/physlr.py
@@ -2352,7 +2352,7 @@ class Physlr:
                     path[curr_pos] = name[:-1] + idxtojoin[max_idx][1]
                     oriented = True
         if not oriented:
-            unoriented.clear()
+            unoriented.append(curr_pos)
 
         return path, unoriented
 

--- a/physlr/physlr.py
+++ b/physlr/physlr.py
@@ -2479,31 +2479,12 @@ class Physlr:
         num_unoriented = sum([1 for path in paths for name in path if name[-1] == "."])
         print(num_unoriented, "unoriented pieces before using ARCS pair information",
               file=sys.stderr)
-        f = open("pathToFasta.txt", "w")
-        num_unoriented = 0
-        old_ori = []
-        for path in paths:
-            for name in path:
-                old_ori.append(name)
-                if name[-1] == ".":
-                    num_unoriented += 1
-        print(num_unoriented, "at the beginning", file=sys.stderr)
-
 
         paths = Physlr.orient_paths(paths, pairs)
 
         num_unoriented = sum([1 for path in paths for name in path if name[-1] == "."])
         print(num_unoriented, "unoriented pieces after using ARCS pair information",
               file=sys.stderr)
-        num_unoriented = 0
-        for path in paths:
-            for name in path:
-                f.write(old_ori.pop(0)+ "\t" + name + "\n")
-                if name[-1] == ".":
-                    num_unoriented += 1
-        print(num_unoriented, "at the end", file=sys.stderr)
-        f.close()
-        sys.exit(0)
 
         for path in paths:
             if not dist:

--- a/physlr/physlr.py
+++ b/physlr/physlr.py
@@ -2479,12 +2479,31 @@ class Physlr:
         num_unoriented = sum([1 for path in paths for name in path if name[-1] == "."])
         print(num_unoriented, "unoriented pieces before using ARCS pair information",
               file=sys.stderr)
+        f = open("pathToFasta.txt", "w")
+        num_unoriented = 0
+        old_ori = []
+        for path in paths:
+            for name in path:
+                old_ori.append(name)
+                if name[-1] == ".":
+                    num_unoriented += 1
+        print(num_unoriented, "at the beginning", file=sys.stderr)
+
 
         paths = Physlr.orient_paths(paths, pairs)
 
         num_unoriented = sum([1 for path in paths for name in path if name[-1] == "."])
         print(num_unoriented, "unoriented pieces after using ARCS pair information",
               file=sys.stderr)
+        num_unoriented = 0
+        for path in paths:
+            for name in path:
+                f.write(old_ori.pop(0)+ "\t" + name + "\n")
+                if name[-1] == ".":
+                    num_unoriented += 1
+        print(num_unoriented, "at the end", file=sys.stderr)
+        f.close()
+        sys.exit(0)
 
         for path in paths:
             if not dist:


### PR DESCRIPTION
When orienting forward, the unoriented list is cleared to begin with so there is no need to clear. In the case that we fail to orient the piece, we would like to orient it backwards by storing it into the unoriented list.