### PR TITLE
limit thread count for python mol-sep

### DIFF
--- a/bin/physlr-make
+++ b/bin/physlr-make
@@ -11,7 +11,13 @@ w=32
 # Number of threads.
 t=16
 
-# distance (depth) for extracting subgraphs
+# Maximum number of threads for molecule separation (python version).
+max_t_py_molsep=4
+ifneq ($(shell test $(t) -gt $(max_t_py_molsep); echo $$?),0)
+max_t_py_molsep=$(t)
+endif
+
+# Distance (depth) for extracting subgraphs
 d=1
 
 # Size of Bloom filter
@@ -929,15 +935,15 @@ endif
 
 # Redo molecule separation on a list of junction-causing barcodes.
 %.mol2.tsv: %.tsv %.junctions.tsv
-	$(time) $(python) $(bin)/physlr molecules -V$V -t$t --separation-strategy=bc $^ >$@
+	$(time) $(python) $(bin)/physlr molecules -V$V -t$(max_t_py_molsep) --separation-strategy=bc $^ >$@
 
 # Redo molecule separation on a list of junction-causing barcodes.
 %.mol2-bcs.tsv: %.tsv %.junctions.tsv
-	$(time) $(python) $(bin)/physlr molecules -V$V -t$t --separation-strategy=bc+cos+sqcos $^ >$@
+	$(time) $(python) $(bin)/physlr molecules -V$V -t$(max_t_py_molsep) --separation-strategy=bc+cos+sqcos $^ >$@
 
 # Redo molecule separation on a list of junction-causing barcodes.
 %.mol2-bkcs.tsv: %.tsv %.junctions.tsv
-	$(time) $(python) $(bin)/physlr molecules -V$V -t$t --separation-strategy=bc+k3+cos+sqcos $^ >$@
+	$(time) $(python) $(bin)/physlr molecules -V$V -t$(max_t_py_molsep) --separation-strategy=bc+k3+cos+sqcos $^ >$@
 
 # Determine the backbone graph from the overlap TSV.
 %.backbone.tsv: %.tsv
@@ -1122,19 +1128,19 @@ g=$(shell awk '{x += $$2} END{print x}' $(name)/$(ref).fa.fai)
 
 # Separate barcodes into molecules.
 %.mol.tsv: %.tsv
-	$(time) $(python) $(bin)/physlr molecules -V$V -t$t --separation-strategy=$(mol_strategy) $< >$@
+	$(time) $(python) $(bin)/physlr molecules -V$V -t$(max_t_py_molsep) --separation-strategy=$(mol_strategy) $< >$@
 
 # Separate barcodes into molecules using K3-clique community detection.
 %.k3.mol.tsv: %.tsv
-	$(time) $(python) $(bin)/physlr molecules -V$V -t$t --separation-strategy=bc+k3 $< >$@
+	$(time) $(python) $(bin)/physlr molecules -V$V -t$(max_t_py_molsep) --separation-strategy=bc+k3 $< >$@
 
 # Separate barcodes into molecules using K3-clique and sqcosbin community detection.
 %.ext.mol.tsv: %.tsv
-	$(time) $(python) $(bin)/physlr molecules -V$V -t$t --separation-strategy=distributed+sqcosbin $< >$@
+	$(time) $(python) $(bin)/physlr molecules -V$V -t$(max_t_py_molsep) --separation-strategy=distributed+sqcosbin $< >$@
 
 # Separate barcodes into molecules using Louvain community detection.
 %.louvain.mol.tsv: %.tsv
-	$(time) $(python) $(bin)/physlr molecules -V$V -t$t --separation-strategy=bc+louvain $< >$@
+	$(time) $(python) $(bin)/physlr molecules -V$V -t$(max_t_py_molsep) --separation-strategy=bc+louvain $< >$@
 
 # Make a vertex-induced subgraph
 %.subgraph-d$d.tsv: %.tsv


### PR DESCRIPTION
As the ram consumption for mol-sep (python version) is multiplied by the number of threads, we can limit it to 4 threads (or a specific max) to avoid using ram much more than other steps.