### PR TITLE
filter-edges-m

### DIFF
--- a/bin/physlr-make
+++ b/bin/physlr-make
@@ -1127,25 +1127,9 @@ g=$(shell awk '{x += $$2} END{print x}' $(name)/$(ref).fa.fai)
 %.cn.tsv: %.tsv
 	$(python) $(bin)/physlr common-neighbours -V$V $< >$@
 
-# Filter edges n >= 10 using Miller.
-%.n10.tsv: %.tsv
-	mlr --tsvlite filter '$$n >= 10' $< >$@
-
-# Filter edges n >= 20 using Miller.
-%.n20.tsv: %.tsv
-	mlr --tsvlite filter '$$n >= 20' $< >$@
-
-# Filter edges n >= 50 using Miller.
-%.n50.tsv: %.tsv
-	mlr --tsvlite filter '$$n >= 50' $< >$@
-
-# Filter edges n >= 100 using Miller.
-%.n100.tsv: %.tsv
-	mlr --tsvlite filter '$$n >= 100' $< >$@
-
-# Filter edges by n using Miller.
+# Filter edges by m using Miller.
 %.n$n.tsv: %.tsv
-	mlr --tsvlite filter '$$n >= $n' $< >$@
+	mlr --tsvlite filter '$$m >= $n' $< >$@
 
 # Filter m% of lowest weighted edges using python.
 %.m$m.tsv: %.tsv


### PR DESCRIPTION
So, we no longer (since before physlr v1) have column `n` in the `.tsv` files so these commands I am omitting will return an empty file. As this functionality is still needed for developers, I am keeping one command that filters `m`, but I use parameter `n` for it as m is already allocated to filter `m%` of lowest weighted edges. may not be the vest solution but couldn't think of any other alternatives.